### PR TITLE
Fix eslint version dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "typescript": "^4.3.5"
   },
   "peerDependencies": {
-    "eslint": "6.x-8.x"
+    "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "lint-staged": {
     "*.ts": [


### PR DESCRIPTION
Currently, the peerDependency syntax for eslint in `package.json` is incorrect, and the dependency isn't being read correctly. This is just a very simple fix to correct the version number.