### PR TITLE
Replace experimental package with stable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "README.md"
   ],
   "dependencies": {
+    "@typescript-eslint/utils": "^5.10.0",
     "is-html": "^2.0.0",
     "jsx-ast-utils": "^3.2.0",
     "kebab-case": "^1.0.1",
@@ -45,7 +46,6 @@
     "@types/markdown-magic": "^1.0.1",
     "@types/node": "^16.4.0",
     "@typescript-eslint/eslint-plugin": "^5.6.0",
-    "@typescript-eslint/experimental-utils": "^5.9.0",
     "@typescript-eslint/parser": "^5.6.0",
     "eslint": "^8.4.1",
     "eslint-plugin-eslint-plugin": "^4.0.3",

--- a/src/rules/jsx-no-undef.ts
+++ b/src/rules/jsx-no-undef.ts
@@ -1,4 +1,4 @@
-import type { TSESTree as T, TSESLint } from "@typescript-eslint/experimental-utils";
+import type { TSESTree as T, TSESLint } from "@typescript-eslint/utils";
 import { isDOMElementName, formatList, getCommentBefore } from "../utils";
 
 // Currently all of the control flow components are from 'solid-js'.

--- a/src/rules/jsx-uses-vars.ts
+++ b/src/rules/jsx-uses-vars.ts
@@ -1,4 +1,4 @@
-import type { TSESTree as T, TSESLint } from "@typescript-eslint/experimental-utils";
+import type { TSESTree as T, TSESLint } from "@typescript-eslint/utils";
 
 /*
  * This rule is lifted almost verbatim from eslint-plugin-react's

--- a/src/rules/no-destructure.ts
+++ b/src/rules/no-destructure.ts
@@ -1,4 +1,4 @@
-import { TSESTree as T, TSESLint, ASTUtils } from "@typescript-eslint/experimental-utils";
+import { TSESTree as T, TSESLint, ASTUtils } from "@typescript-eslint/utils";
 import type { FunctionNode } from "../utils";
 
 const { getStringIfConstant } = ASTUtils;

--- a/src/rules/no-innerhtml.ts
+++ b/src/rules/no-innerhtml.ts
@@ -1,4 +1,4 @@
-import { TSESLint, ASTUtils } from "@typescript-eslint/experimental-utils";
+import { TSESLint, ASTUtils } from "@typescript-eslint/utils";
 import { propName } from "jsx-ast-utils";
 import isHtml from "is-html";
 

--- a/src/rules/no-react-specific-props.ts
+++ b/src/rules/no-react-specific-props.ts
@@ -1,4 +1,4 @@
-import type { TSESLint } from "@typescript-eslint/experimental-utils";
+import type { TSESLint } from "@typescript-eslint/utils";
 import { getProp, hasProp } from "jsx-ast-utils";
 
 const reactSpecificProps = [

--- a/src/rules/no-unknown-namespaces.ts
+++ b/src/rules/no-unknown-namespaces.ts
@@ -1,4 +1,4 @@
-import type { TSESLint, TSESTree as T } from "@typescript-eslint/experimental-utils";
+import type { TSESLint, TSESTree as T } from "@typescript-eslint/utils";
 
 const knownNamespaces = ["on", "oncapture", "use", "prop", "attr"];
 const styleNamespaces = ["style", "class"];

--- a/src/rules/prefer-classlist.ts
+++ b/src/rules/prefer-classlist.ts
@@ -1,4 +1,4 @@
-import type { TSESLint, TSESTree as T } from "@typescript-eslint/experimental-utils";
+import type { TSESLint, TSESTree as T } from "@typescript-eslint/utils";
 import { hasProp, propName } from "jsx-ast-utils";
 
 const rule: TSESLint.RuleModule<"preferClasslist", [{ classnames?: [string, ...Array<string>] }?]> =

--- a/src/rules/prefer-for.ts
+++ b/src/rules/prefer-for.ts
@@ -1,4 +1,4 @@
-import { TSESLint, TSESTree as T, ASTUtils } from "@typescript-eslint/experimental-utils";
+import { TSESLint, TSESTree as T, ASTUtils } from "@typescript-eslint/utils";
 import { isFunctionNode } from "../utils";
 
 const { getPropertyName } = ASTUtils;

--- a/src/rules/reactivity.ts
+++ b/src/rules/reactivity.ts
@@ -3,7 +3,7 @@
  * @link https://github.com/joshwilsonvu/eslint-plugin-solid/blob/main/docs/reactivity.md
  */
 
-import { TSESTree as T, TSESLint, ASTUtils } from "@typescript-eslint/experimental-utils";
+import { TSESTree as T, TSESLint, ASTUtils } from "@typescript-eslint/utils";
 import {
   findParent,
   findInScope,

--- a/src/rules/style-prop.ts
+++ b/src/rules/style-prop.ts
@@ -1,4 +1,4 @@
-import { TSESLint, TSESTree as T, ASTUtils } from "@typescript-eslint/experimental-utils";
+import { TSESLint, TSESTree as T, ASTUtils } from "@typescript-eslint/utils";
 import kebabCase from "kebab-case";
 import { all as allCssProperties } from "known-css-properties";
 import parse from "style-to-object";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import type { TSESTree as T, TSESLint } from "@typescript-eslint/experimental-utils";
+import type { TSESTree as T, TSESLint } from "@typescript-eslint/utils";
 
 const domElementRegex = /^[a-z]/;
 export const isDOMElementName = (name: string): boolean => domElementRegex.test(name);

--- a/test/ruleTester.ts
+++ b/test/ruleTester.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from "@typescript-eslint/experimental-utils";
+import { TSESLint } from "@typescript-eslint/utils";
 // @ts-ignore
 import { RuleTester as RuleTester_v6 } from "eslint-v6";
 // @ts-ignore

--- a/test/rules/no-innerhtml.test.ts
+++ b/test/rules/no-innerhtml.test.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES as T } from "@typescript-eslint/experimental-utils";
+import { AST_NODE_TYPES as T } from "@typescript-eslint/utils";
 import { run } from "../ruleTester";
 import rule from "../../src/rules/no-innerhtml";
 

--- a/test/rules/reactivity.test.ts
+++ b/test/rules/reactivity.test.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES as T } from "@typescript-eslint/experimental-utils";
+import { AST_NODE_TYPES as T } from "@typescript-eslint/utils";
 import { run } from "../ruleTester";
 import rule from "../../src/rules/reactivity";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1085,18 +1085,6 @@
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/experimental-utils@^5.9.0":
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.9.0.tgz#652762d37d6565ef07af285021b8347b6c79a827"
-  integrity sha512-ZnLVjBrf26dn7ElyaSKa6uDhqwvAi4jBBmHK1VxuFGPRAxhdi18ubQYSGA7SRiFiES3q9JiBOBHEBStOFkwD2g==
-  dependencies:
-    "@types/json-schema" "^7.0.9"
-    "@typescript-eslint/scope-manager" "5.9.0"
-    "@typescript-eslint/types" "5.9.0"
-    "@typescript-eslint/typescript-estree" "5.9.0"
-    eslint-scope "^5.1.1"
-    eslint-utils "^3.0.0"
-
 "@typescript-eslint/parser@^5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.6.0.tgz#11677324659641400d653253c03dcfbed468d199"
@@ -1107,6 +1095,14 @@
     "@typescript-eslint/typescript-estree" "5.6.0"
     debug "^4.3.2"
 
+"@typescript-eslint/scope-manager@5.10.0":
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.10.0.tgz#bb5d872e8b9e36203908595507fbc4d3105329cb"
+  integrity sha512-tgNgUgb4MhqK6DoKn3RBhyZ9aJga7EQrw+2/OiDk5hKf3pTVZWyqBi7ukP+Z0iEEDMF5FDa64LqODzlfE4O/Dg==
+  dependencies:
+    "@typescript-eslint/types" "5.10.0"
+    "@typescript-eslint/visitor-keys" "5.10.0"
+
 "@typescript-eslint/scope-manager@5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.6.0.tgz#9dd7f007dc8f3a34cdff6f79f5eaab27ae05157e"
@@ -1115,23 +1111,28 @@
     "@typescript-eslint/types" "5.6.0"
     "@typescript-eslint/visitor-keys" "5.6.0"
 
-"@typescript-eslint/scope-manager@5.9.0":
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.9.0.tgz#02dfef920290c1dcd7b1999455a3eaae7a1a3117"
-  integrity sha512-DKtdIL49Qxk2a8icF6whRk7uThuVz4A6TCXfjdJSwOsf+9ree7vgQWcx0KOyCdk0i9ETX666p4aMhrRhxhUkyg==
-  dependencies:
-    "@typescript-eslint/types" "5.9.0"
-    "@typescript-eslint/visitor-keys" "5.9.0"
+"@typescript-eslint/types@5.10.0":
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.10.0.tgz#beb3cb345076f5b088afe996d57bcd1dfddaa75c"
+  integrity sha512-wUljCgkqHsMZbw60IbOqT/puLfyqqD5PquGiBo1u1IS3PLxdi3RDGlyf032IJyh+eQoGhz9kzhtZa+VC4eWTlQ==
 
 "@typescript-eslint/types@5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.6.0.tgz#745cb1b59daadcc1f32f7be95f0f68accf38afdd"
   integrity sha512-OIZffked7mXv4mXzWU5MgAEbCf9ecNJBKi+Si6/I9PpTaj+cf2x58h2oHW5/P/yTnPkKaayfjhLvx+crnl5ubA==
 
-"@typescript-eslint/types@5.9.0":
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.9.0.tgz#e5619803e39d24a03b3369506df196355736e1a3"
-  integrity sha512-mWp6/b56Umo1rwyGCk8fPIzb9Migo8YOniBGPAQDNC6C52SeyNGN4gsVwQTAR+RS2L5xyajON4hOLwAGwPtUwg==
+"@typescript-eslint/typescript-estree@5.10.0":
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.0.tgz#4be24a3dea0f930bb1397c46187d0efdd955a224"
+  integrity sha512-x+7e5IqfwLwsxTdliHRtlIYkgdtYXzE0CkFeV6ytAqq431ZyxCFzNMNR5sr3WOlIG/ihVZr9K/y71VHTF/DUQA==
+  dependencies:
+    "@typescript-eslint/types" "5.10.0"
+    "@typescript-eslint/visitor-keys" "5.10.0"
+    debug "^4.3.2"
+    globby "^11.0.4"
+    is-glob "^4.0.3"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
 
 "@typescript-eslint/typescript-estree@5.6.0":
   version "5.6.0"
@@ -1146,18 +1147,25 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/typescript-estree@5.9.0":
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.9.0.tgz#0e5c6f03f982931abbfbc3c1b9df5fbf92a3490f"
-  integrity sha512-kxo3xL2mB7XmiVZcECbaDwYCt3qFXz99tBSuVJR4L/sR7CJ+UNAPrYILILktGj1ppfZ/jNt/cWYbziJUlHl1Pw==
+"@typescript-eslint/utils@^5.10.0":
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.10.0.tgz#c3d152a85da77c400e37281355561c72fb1b5a65"
+  integrity sha512-IGYwlt1CVcFoE2ueW4/ioEwybR60RAdGeiJX/iDAw0t5w0wK3S7QncDwpmsM70nKgGTuVchEWB8lwZwHqPAWRg==
   dependencies:
-    "@typescript-eslint/types" "5.9.0"
-    "@typescript-eslint/visitor-keys" "5.9.0"
-    debug "^4.3.2"
-    globby "^11.0.4"
-    is-glob "^4.0.3"
-    semver "^7.3.5"
-    tsutils "^3.21.0"
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.10.0"
+    "@typescript-eslint/types" "5.10.0"
+    "@typescript-eslint/typescript-estree" "5.10.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
+"@typescript-eslint/visitor-keys@5.10.0":
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.0.tgz#770215497ad67cd15a572b52089991d5dfe06281"
+  integrity sha512-GMxj0K1uyrFLPKASLmZzCuSddmjZVbVj3Ouy5QVuIGKZopxvOr24JsS7gruz6C3GExE01mublZ3mIBOaon9zuQ==
+  dependencies:
+    "@typescript-eslint/types" "5.10.0"
+    eslint-visitor-keys "^3.0.0"
 
 "@typescript-eslint/visitor-keys@5.6.0":
   version "5.6.0"
@@ -1165,14 +1173,6 @@
   integrity sha512-1p7hDp5cpRFUyE3+lvA74egs+RWSgumrBpzBCDzfTFv0aQ7lIeay80yU0hIxgAhwQ6PcasW35kaOCyDOv6O/Ng==
   dependencies:
     "@typescript-eslint/types" "5.6.0"
-    eslint-visitor-keys "^3.0.0"
-
-"@typescript-eslint/visitor-keys@5.9.0":
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.9.0.tgz#7585677732365e9d27f1878150fab3922784a1a6"
-  integrity sha512-6zq0mb7LV0ThExKlecvpfepiB+XEtFv/bzx7/jKSgyXTFD7qjmSu1FoiS0x3OZaiS+UIXpH2vd9O89f02RCtgw==
-  dependencies:
-    "@typescript-eslint/types" "5.9.0"
     eslint-visitor-keys "^3.0.0"
 
 abab@^2.0.3, abab@^2.0.5:


### PR DESCRIPTION
While trying to use this plugin I found that `@typescript-eslint/experimental-utils` was marked as `devDependency` but had a non-type import in one file. In other words the plugin fails because it can't resolve this package.

So I wanted to move it to `dependencies` but apparently a few days ago the `@typescript-eslint/utils` package was released so I just replaced it with that.