### PR TITLE
fix: disallow extra properties in rule options

### DIFF
--- a/packages/eslint-plugin-solid/src/rules/jsx-no-duplicate-props.ts
+++ b/packages/eslint-plugin-solid/src/rules/jsx-no-duplicate-props.ts
@@ -36,6 +36,7 @@ export default createRule<Options, MessageIds>({
             default: false,
           },
         },
+        additionalProperties: false,
       },
     ],
     messages: {


### PR DESCRIPTION
[jsx-no-duplicate-props](https://github.com/solidjs-community/eslint-plugin-solid/blob/8a17adecb2451bb1cacf8add07d68f2a49bb3614/packages/eslint-plugin-solid/src/rules/jsx-no-duplicate-props.ts#L30) rule currently allows extra properties to be passed in options object, which should not be allowed. This makes it easier for typos in rule options to go unnoticed.

This PR simply disallows extra properties in this rule's schema.