### PR TITLE
Add object numeric destructuring for reactivity rule

### DIFF
--- a/packages/eslint-plugin-solid/src/rules/reactivity.ts
+++ b/packages/eslint-plugin-solid/src/rules/reactivity.ts
@@ -7,8 +7,7 @@ import {
   TSESTree as T,
   TSESLint,
   ESLintUtils,
-  ASTUtils,
-  AST_NODE_TYPES,
+  ASTUtils
 } from "@typescript-eslint/utils";
 import { traverse } from "estraverse";
 import {

--- a/packages/eslint-plugin-solid/test/rules/reactivity.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/reactivity.test.ts
@@ -180,6 +180,16 @@ export const cases = run("reactivity", rule, {
     element.addEventListener("click", () => {
       console.log(signal());
     }, { once: true });`,
+    `const {0: signal, 1: setSignal} = createSignal(1);
+    const element = document.getElementById("id");
+    element.onclick = () => {
+      console.log(signal());
+    };`,
+    `const {'0': signal, '1': setSignal} = createSignal(1);
+    const element = document.getElementById("id");
+    element.onclick = () => {
+      console.log(signal());
+    };`,
     `const [signal, setSignal] = createSignal(1);
     const element = document.getElementById("id");
     element.onclick = () => {
@@ -223,11 +233,22 @@ export const cases = run("reactivity", rule, {
       return <div>{count()}</div>;
     }`,
     `function Component(props) {
+      const {0: count, 1: setCount} = useSignal(props.initialCount);
+      return <div>{count()}</div>;
+    }`,
+    `function Component(props) {
       const [count, setCount] = useSignal(props.defaultCount);
       return <div>{count()}</div>;
     }`,
     // Store getters
     `const [state, setState] = createStore({
+      firstName: 'Will',
+      lastName: 'Smith',
+      get fullName() {
+        return state.firstName + " " + state.lastName;
+      }
+    });`,
+    `const {0: state, 1: setState} = createStore({
       firstName: 'Will',
       lastName: 'Smith',
       get fullName() {
@@ -565,6 +586,19 @@ export const cases = run("reactivity", rule, {
           messageId: "shouldDestructure",
           data: { nth: "first " },
           type: T.ArrayPattern,
+        },
+      ],
+    },
+    {
+      code: `
+      const Component = () => {
+        const {2: signal, 3: setSignal} = createSignal();
+      }`,
+      errors: [
+        {
+          messageId: "shouldDestructure",
+          data: { nth: "first " },
+          type: T.ObjectPattern,
         },
       ],
     },


### PR DESCRIPTION
PR is about making next code to pass as valid
`
const {0: signal, 1: signal} = createSignal(5);
// ... assume later correct signal usage
`
`
const {'0': signal, '1': signal} = createSignal(5);
// ... assume later correct signal usage
`

Reason for adding this is because array destructuring in specs is defined using iterator, for more info please check next article (not mine): https://medium.com/@P0lip/array-destructuring-revisited-a43d991d1920 