### PR TITLE
v0.16.0 — Solid 2.0 rule layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ typings/
 
 # Turbo cache
 .turbo
+
+# Local pnpm store (created by sandboxed installs)
+.pnpm-store

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ runs under [Oxlint](#oxlint) as a JS plugin.
   - [Installation](#installation)
   - [Configuration](#configuration)
     - [TypeScript](#typescript)
+    - [Solid 2.0](#solid-20)
     - [Manual Configuration](#manual-configuration)
     - [Oxlint](#oxlint)
   - [Rules](#rules)
@@ -107,10 +108,35 @@ export default [
 ];
 ```
 
-Both configs are also available on the plugin's root export, as `solid.configs.recommended` and
-`solid.configs.typescript`, after using `import solid from 'eslint-plugin-solid'`. (The
-`configs["flat/recommended"]` and `configs["flat/typescript"]` names from v0.14.x still work as
-aliases.)
+### Solid 2.0
+
+If your project targets Solid 2.0, use the `v2` configuration. It sets
+`settings: { solid: { version: 2 } }`, which switches the version-aware rules (`reactivity`,
+`imports`, `no-unknown-namespaces`, `event-handlers`, `jsx-no-undef`) to strict 2.0 semantics, and
+enables the 2.0-specific rules: `removed-api`, `no-single-arg-create-effect`, `no-accessor-as-prop`
+as errors and `prefer-structured-class` as a warning. This is the config the official Solid 2.0
+templates ship with.
+
+```js
+import js from "@eslint/js";
+import solid from "eslint-plugin-solid/configs/v2";
+
+export default [js.configs.recommended, solid];
+```
+
+There is also a `v2-strict` configuration with the plugin's strongest opinions: everything in `v2`
+plus `no-module-scope-reactive-primitive` and `no-restated-default-options` as errors,
+`prefer-onSettled-for-side-effects` as a warning, and `prefer-structured-class` promoted to an
+error.
+
+The `settings.solid.version` setting also works in any custom config; version-aware rules read it
+directly, so you can opt individual rule configurations into 2.0 semantics without using the
+presets.
+
+All configs are also available on the plugin's root export, as `solid.configs.recommended`,
+`solid.configs.typescript`, `solid.configs.v2`, and `solid.configs["v2-strict"]`, after using
+`import solid from 'eslint-plugin-solid'`. (The `configs["flat/recommended"]` and
+`configs["flat/typescript"]` names from v0.14.x still work as aliases.)
 
 These configurations do not configure global variables in ESLint. You can do this yourself manually
 or with a package like [globals](https://www.npmjs.com/package/globals) by creating a configuration
@@ -161,6 +187,11 @@ the plugin to `jsPlugins` in your `.oxlintrc.json` and enable the rules you want
 }
 ```
 
+For Solid 2.0 projects, add `"settings": { "solid": { "version": 2 } }` to activate the
+version-aware rule behavior, and enable the 2.0 rules (`solid/removed-api`,
+`solid/no-single-arg-create-effect`, `solid/no-accessor-as-prop`,
+`solid/prefer-structured-class`).
+
 ## Rules
 
 ✔: Enabled in the `recommended` configuration.
@@ -177,17 +208,24 @@ the plugin to `jsPlugins` in your `.oxlintrc.json` and enable the rules you want
 | ✔ |  | [solid/jsx-no-script-url](/packages/eslint-plugin-solid/docs/jsx-no-script-url.md) | Disallow javascript: URLs. |
 | ✔ | 🔧 | [solid/jsx-no-undef](/packages/eslint-plugin-solid/docs/jsx-no-undef.md) | Disallow references to undefined variables in JSX. Handles custom directives. |
 | ✔ |  | [solid/jsx-uses-vars](/packages/eslint-plugin-solid/docs/jsx-uses-vars.md) | Prevent variables used in JSX from being marked as unused. |
+|  |  | [solid/no-accessor-as-prop](/packages/eslint-plugin-solid/docs/no-accessor-as-prop.md) | Disallow passing uncalled signal accessors or other functions as value-typed DOM element attributes. |
 |  |  | [solid/no-array-handlers](/packages/eslint-plugin-solid/docs/no-array-handlers.md) | Disallow usage of type-unsafe event handlers. |
 | ✔ | 🔧 | [solid/no-destructure](/packages/eslint-plugin-solid/docs/no-destructure.md) | Disallow destructuring props. In Solid, props must be used with property accesses (`props.foo`) to preserve reactivity. This rule only tracks destructuring in the parameter list. |
 | ✔ | 🔧 | [solid/no-innerhtml](/packages/eslint-plugin-solid/docs/no-innerhtml.md) | Disallow usage of the innerHTML attribute, which can often lead to security vulnerabilities. |
+|  |  | [solid/no-module-scope-reactive-primitive](/packages/eslint-plugin-solid/docs/no-module-scope-reactive-primitive.md) | Disallow reactive primitives at module scope, where state is shared across SSR requests. |
 |  |  | [solid/no-proxy-apis](/packages/eslint-plugin-solid/docs/no-proxy-apis.md) | Disallow usage of APIs that use ES6 Proxies, only to target environments that don't support them. |
 | ✔ | 🔧 | [solid/no-react-deps](/packages/eslint-plugin-solid/docs/no-react-deps.md) | Disallow usage of dependency arrays in `createEffect` and `createMemo`. |
 | ✔ | 🔧 | [solid/no-react-specific-props](/packages/eslint-plugin-solid/docs/no-react-specific-props.md) | Disallow usage of React-specific `className`/`htmlFor` props, which were deprecated in v1.4.0. |
+|  | 🔧 | [solid/no-restated-default-options](/packages/eslint-plugin-solid/docs/no-restated-default-options.md) | Disallow restating a prop or option value that is already the default. |
+|  |  | [solid/no-single-arg-create-effect](/packages/eslint-plugin-solid/docs/no-single-arg-create-effect.md) | Require the two-argument `createEffect(compute, effect)` form used by Solid 2.0. |
 | ✔ |  | [solid/no-unknown-namespaces](/packages/eslint-plugin-solid/docs/no-unknown-namespaces.md) | Enforce using only Solid-specific namespaced attribute names (i.e. `'on:'` in `<div on:click={...} />`). |
 |  | 🔧 | [solid/prefer-classlist](/packages/eslint-plugin-solid/docs/prefer-classlist.md) | Enforce using the classlist prop over importing a classnames helper. The classlist prop accepts an object `{ [class: string]: boolean }` just like classnames. |
 | ✔ | 🔧 | [solid/prefer-for](/packages/eslint-plugin-solid/docs/prefer-for.md) | Enforce using Solid's `<For />` component for mapping an array to JSX elements. |
+|  |  | [solid/prefer-onSettled-for-side-effects](/packages/eslint-plugin-solid/docs/prefer-onSettled-for-side-effects.md) | Enforce running side-effectful setup (timers, global listeners, observers) inside `onSettled` instead of the component body. |
 |  | 🔧 | [solid/prefer-show](/packages/eslint-plugin-solid/docs/prefer-show.md) | Enforce using Solid's `<Show />` component for conditionally showing content. Solid's compiler covers this case, so it's a stylistic rule only. |
+|  |  | [solid/prefer-structured-class](/packages/eslint-plugin-solid/docs/prefer-structured-class.md) | Enforce using the structured array/object forms of the `class` prop over manually-built class strings. |
 | ✔ |  | [solid/reactivity](/packages/eslint-plugin-solid/docs/reactivity.md) | Enforce that reactivity (props, signals, memos, etc.) is properly used, so changes in those values will be tracked and update the view as expected. |
+|  | 🔧 | [solid/removed-api](/packages/eslint-plugin-solid/docs/removed-api.md) | Disallow Solid 1.x APIs that were removed or renamed in Solid 2.0, with migration guidance. |
 | ✔ | 🔧 | [solid/self-closing-comp](/packages/eslint-plugin-solid/docs/self-closing-comp.md) | Disallow extra closing tags for components without children. |
 | ✔ | 🔧 | [solid/style-prop](/packages/eslint-plugin-solid/docs/style-prop.md) | Require CSS properties in the `style` prop to be valid and kebab-cased (ex. 'font-size'), not camel-cased (ex. 'fontSize') like in React, and that property values with dimensions are strings, not numbers with implicit 'px' units. |
 <!-- end-doc-gen -->
@@ -213,8 +251,8 @@ issue](https://github.com/solidjs-community/eslint-plugin-solid/issues/new/choos
 
 ## Versioning
 
-Pre-1.0.0, the rules and the `recommended` and `typescript` configuations will be
-stable across patch (`0.0.x`) versions, but may change across minor (`0.x`) versions.
+Pre-1.0.0, the rules and the `recommended`, `typescript`, `v2`, and `v2-strict` configurations
+will be stable across patch (`0.0.x`) versions, but may change across minor (`0.x`) versions.
 If you want to pin a minor version, use a tilde in your `package.json`.
 
 <!-- doc-gen TILDE -->

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ If you want to pin a minor version, use a tilde in your `package.json`.
 
 <!-- doc-gen TILDE -->
 ```diff
-- "eslint-plugin-solid": "^0.15.0"
-+ "eslint-plugin-solid": "~0.15.0"
+- "eslint-plugin-solid": "^0.16.0"
++ "eslint-plugin-solid": "~0.16.0"
 ```
 <!-- end-doc-gen -->

--- a/packages/eslint-plugin-solid/CHANGELOG.md
+++ b/packages/eslint-plugin-solid/CHANGELOG.md
@@ -1,5 +1,73 @@
 # Changelog
 
+## 0.16.0
+
+The complete Solid 2.0 lint surface: version-aware rules, new `v2` / `v2-strict` configs, and a
+full set of 2.0-specific rules, all vetted against the official Solid 2.0 templates (which lint
+clean with zero errors and zero warnings under the `v2` config).
+
+### Features
+
+- **`settings.solid.version`.** Rules can now read the targeted Solid major version from ESLint
+  settings (`settings: { solid: { version: 2 } }`). Unset means the permissive dual-version
+  behavior from 0.15. The new configs preset it; any custom config can opt in with one line.
+- **New `v2` config** (`eslint-plugin-solid/configs/v2`, also `solid.configs.v2`): what the
+  official Solid 2.0 templates ship. Sets the version setting, switches existing rules to strict
+  2.0 semantics, and enables the new 2.0 rules — errors are reserved for near-certain bugs,
+  heuristics stay warnings.
+- **New `v2-strict` config** (`eslint-plugin-solid/configs/v2-strict`): everything in `v2` plus
+  the plugin's strongest opinions (see below).
+- **New rule `solid/removed-api`** (error in `v2`): flags removed/renamed 1.x APIs with
+  autofixes where mechanical (`onMount`→`onSettled`, `batch`→`flush`, `mergeProps`→`merge`,
+  `unwrap`→`snapshot`, `equalFn`→`isEqual`, `getListener`→`getObserver`,
+  `classList={{...}}`→`class={{...}}`, `"solid-js/web"`→`"@solidjs/web"`,
+  `"solid-js/store"`→`"solid-js"`) and prescriptive migration messages otherwise
+  (`createResource`, `on`, `Suspense`→`Loading`, `Index`→`<For keyed={false}>`, `produce`, etc.).
+  Lists verified against the Solid 2.0 RC source.
+- **New rule `solid/no-single-arg-create-effect`** (error in `v2`): Solid 2.0 requires the split
+  `createEffect(compute, effect)` form. The single-argument 1.x form produces no TS compile error
+  on a bare statement call and only throws at runtime in dev mode; this rule is the build-time
+  hard stop for the most commonly reproduced AI mistake.
+- **New rule `solid/no-accessor-as-prop`** (error in `v2`): `<div title={count} />` silently
+  renders a stringified function. Fires on any expression that statically resolves to a function
+  in a value-typed DOM attribute, with a message that states the fix (`count` → `count()`).
+  Event handlers, `ref`, `children`, namespaced attributes, components, and custom elements are
+  exempt.
+- **New rule `solid/prefer-structured-class`** (warning in `v2`, error in `v2-strict`): nudges
+  manually-built class strings (concatenation with conditionals, conditional template literals,
+  `.join(" ")`) toward the structured array/object `ClassValue` forms that Solid 2.0 accepts
+  natively. Static strings and plain interpolation are untouched.
+- **New rule `solid/no-module-scope-reactive-primitive`** (error in `v2-strict` only): reactive
+  state at module scope is shared across SSR requests. `createRoot`-wrapped module state is the
+  deliberate escape hatch and is not flagged.
+- **New rule `solid/prefer-onSettled-for-side-effects`** (warning in `v2-strict` only): flags
+  side-effectful setup (timers, global listeners, observers) in component bodies, where it also
+  runs during SSR; suggests `onSettled`. Never flags `onCleanup` itself.
+- **New rule `solid/no-restated-default-options`** (error in `v2-strict` only, autofixable):
+  removes restated defaults like `<For keyed={true}>` and `<Show keyed={false}>`.
+- **Version-2 behavior in existing rules** (active when `settings.solid.version` is 2):
+  - `solid/no-unknown-namespaces` inverts its premise: namespaces are no longer reserved in 2.0,
+    so any colon-name is a legal literal attribute — but the formerly-special prefixes `use:`,
+    `attr:`, `bool:`, `on:`, and `oncapture:` are flagged as near-certain 1.x migration bugs with
+    per-prefix guidance. `prop:` remains the only special namespace.
+  - `solid/event-handlers` graduates from style to correctness: only camelCase `onClick` is an
+    event handler in 2.0; a lowercase `onclick` with a function value is a listener that will
+    never fire (autofixed to camelCase for known DOM events). Lowercase names with static string
+    values are legitimate literal attributes and are no longer flagged. `onDoubleClick` (which
+    lowercases to a nonexistent DOM event) is autofixed to `onDblClick`.
+  - `solid/imports` requires the 2.0 export locations: store exports from core `"solid-js"`, web
+    exports from `"@solidjs/web"`. The legacy `solid-js/store` / `solid-js/web` subpaths are
+    `solid/removed-api`'s territory, avoiding double reports.
+  - `solid/jsx-no-undef` auto-imports the 2.0 control-flow components (`For`, `Repeat`, `Show`,
+    `Switch`, `Match`, `Errored`, `Loading`, `Reveal`); `Index` is no longer suggested.
+  - `solid/reactivity` delegates its uncalled-signal-in-DOM-attribute case to
+    `solid/no-accessor-as-prop` so a node never gets two reports.
+  - `solid/no-react-deps` self-gates off (a dependency array in the second argument is already a
+    type and runtime error in 2.0).
+- **Template vetting.** A fixture test runs the `v2` config over sources copied from the official
+  Solid 2.0 templates in CI, and `test/lint-templates.mjs` sweeps a local `solidjs/templates`
+  checkout. All eleven `solid-v2/*` templates lint clean.
+
 ## 0.15.0
 
 The revival release: Solid 2.0 support and a modernized toolchain.

--- a/packages/eslint-plugin-solid/README.md
+++ b/packages/eslint-plugin-solid/README.md
@@ -21,6 +21,7 @@ runs under [Oxlint](#oxlint) as a JS plugin.
   - [Installation](#installation)
   - [Configuration](#configuration)
     - [TypeScript](#typescript)
+    - [Solid 2.0](#solid-20)
     - [Manual Configuration](#manual-configuration)
     - [Oxlint](#oxlint)
   - [Rules](#rules)
@@ -107,10 +108,35 @@ export default [
 ];
 ```
 
-Both configs are also available on the plugin's root export, as `solid.configs.recommended` and
-`solid.configs.typescript`, after using `import solid from 'eslint-plugin-solid'`. (The
-`configs["flat/recommended"]` and `configs["flat/typescript"]` names from v0.14.x still work as
-aliases.)
+### Solid 2.0
+
+If your project targets Solid 2.0, use the `v2` configuration. It sets
+`settings: { solid: { version: 2 } }`, which switches the version-aware rules (`reactivity`,
+`imports`, `no-unknown-namespaces`, `event-handlers`, `jsx-no-undef`) to strict 2.0 semantics, and
+enables the 2.0-specific rules: `removed-api`, `no-single-arg-create-effect`, `no-accessor-as-prop`
+as errors and `prefer-structured-class` as a warning. This is the config the official Solid 2.0
+templates ship with.
+
+```js
+import js from "@eslint/js";
+import solid from "eslint-plugin-solid/configs/v2";
+
+export default [js.configs.recommended, solid];
+```
+
+There is also a `v2-strict` configuration with the plugin's strongest opinions: everything in `v2`
+plus `no-module-scope-reactive-primitive` and `no-restated-default-options` as errors,
+`prefer-onSettled-for-side-effects` as a warning, and `prefer-structured-class` promoted to an
+error.
+
+The `settings.solid.version` setting also works in any custom config; version-aware rules read it
+directly, so you can opt individual rule configurations into 2.0 semantics without using the
+presets.
+
+All configs are also available on the plugin's root export, as `solid.configs.recommended`,
+`solid.configs.typescript`, `solid.configs.v2`, and `solid.configs["v2-strict"]`, after using
+`import solid from 'eslint-plugin-solid'`. (The `configs["flat/recommended"]` and
+`configs["flat/typescript"]` names from v0.14.x still work as aliases.)
 
 These configurations do not configure global variables in ESLint. You can do this yourself manually
 or with a package like [globals](https://www.npmjs.com/package/globals) by creating a configuration
@@ -161,6 +187,11 @@ the plugin to `jsPlugins` in your `.oxlintrc.json` and enable the rules you want
 }
 ```
 
+For Solid 2.0 projects, add `"settings": { "solid": { "version": 2 } }` to activate the
+version-aware rule behavior, and enable the 2.0 rules (`solid/removed-api`,
+`solid/no-single-arg-create-effect`, `solid/no-accessor-as-prop`,
+`solid/prefer-structured-class`).
+
 ## Rules
 
 ✔: Enabled in the `recommended` configuration.
@@ -177,17 +208,24 @@ the plugin to `jsPlugins` in your `.oxlintrc.json` and enable the rules you want
 | ✔ |  | [solid/jsx-no-script-url](/packages/eslint-plugin-solid/docs/jsx-no-script-url.md) | Disallow javascript: URLs. |
 | ✔ | 🔧 | [solid/jsx-no-undef](/packages/eslint-plugin-solid/docs/jsx-no-undef.md) | Disallow references to undefined variables in JSX. Handles custom directives. |
 | ✔ |  | [solid/jsx-uses-vars](/packages/eslint-plugin-solid/docs/jsx-uses-vars.md) | Prevent variables used in JSX from being marked as unused. |
+|  |  | [solid/no-accessor-as-prop](/packages/eslint-plugin-solid/docs/no-accessor-as-prop.md) | Disallow passing uncalled signal accessors or other functions as value-typed DOM element attributes. |
 |  |  | [solid/no-array-handlers](/packages/eslint-plugin-solid/docs/no-array-handlers.md) | Disallow usage of type-unsafe event handlers. |
 | ✔ | 🔧 | [solid/no-destructure](/packages/eslint-plugin-solid/docs/no-destructure.md) | Disallow destructuring props. In Solid, props must be used with property accesses (`props.foo`) to preserve reactivity. This rule only tracks destructuring in the parameter list. |
 | ✔ | 🔧 | [solid/no-innerhtml](/packages/eslint-plugin-solid/docs/no-innerhtml.md) | Disallow usage of the innerHTML attribute, which can often lead to security vulnerabilities. |
+|  |  | [solid/no-module-scope-reactive-primitive](/packages/eslint-plugin-solid/docs/no-module-scope-reactive-primitive.md) | Disallow reactive primitives at module scope, where state is shared across SSR requests. |
 |  |  | [solid/no-proxy-apis](/packages/eslint-plugin-solid/docs/no-proxy-apis.md) | Disallow usage of APIs that use ES6 Proxies, only to target environments that don't support them. |
 | ✔ | 🔧 | [solid/no-react-deps](/packages/eslint-plugin-solid/docs/no-react-deps.md) | Disallow usage of dependency arrays in `createEffect` and `createMemo`. |
 | ✔ | 🔧 | [solid/no-react-specific-props](/packages/eslint-plugin-solid/docs/no-react-specific-props.md) | Disallow usage of React-specific `className`/`htmlFor` props, which were deprecated in v1.4.0. |
+|  | 🔧 | [solid/no-restated-default-options](/packages/eslint-plugin-solid/docs/no-restated-default-options.md) | Disallow restating a prop or option value that is already the default. |
+|  |  | [solid/no-single-arg-create-effect](/packages/eslint-plugin-solid/docs/no-single-arg-create-effect.md) | Require the two-argument `createEffect(compute, effect)` form used by Solid 2.0. |
 | ✔ |  | [solid/no-unknown-namespaces](/packages/eslint-plugin-solid/docs/no-unknown-namespaces.md) | Enforce using only Solid-specific namespaced attribute names (i.e. `'on:'` in `<div on:click={...} />`). |
 |  | 🔧 | [solid/prefer-classlist](/packages/eslint-plugin-solid/docs/prefer-classlist.md) | Enforce using the classlist prop over importing a classnames helper. The classlist prop accepts an object `{ [class: string]: boolean }` just like classnames. |
 | ✔ | 🔧 | [solid/prefer-for](/packages/eslint-plugin-solid/docs/prefer-for.md) | Enforce using Solid's `<For />` component for mapping an array to JSX elements. |
+|  |  | [solid/prefer-onSettled-for-side-effects](/packages/eslint-plugin-solid/docs/prefer-onSettled-for-side-effects.md) | Enforce running side-effectful setup (timers, global listeners, observers) inside `onSettled` instead of the component body. |
 |  | 🔧 | [solid/prefer-show](/packages/eslint-plugin-solid/docs/prefer-show.md) | Enforce using Solid's `<Show />` component for conditionally showing content. Solid's compiler covers this case, so it's a stylistic rule only. |
+|  |  | [solid/prefer-structured-class](/packages/eslint-plugin-solid/docs/prefer-structured-class.md) | Enforce using the structured array/object forms of the `class` prop over manually-built class strings. |
 | ✔ |  | [solid/reactivity](/packages/eslint-plugin-solid/docs/reactivity.md) | Enforce that reactivity (props, signals, memos, etc.) is properly used, so changes in those values will be tracked and update the view as expected. |
+|  | 🔧 | [solid/removed-api](/packages/eslint-plugin-solid/docs/removed-api.md) | Disallow Solid 1.x APIs that were removed or renamed in Solid 2.0, with migration guidance. |
 | ✔ | 🔧 | [solid/self-closing-comp](/packages/eslint-plugin-solid/docs/self-closing-comp.md) | Disallow extra closing tags for components without children. |
 | ✔ | 🔧 | [solid/style-prop](/packages/eslint-plugin-solid/docs/style-prop.md) | Require CSS properties in the `style` prop to be valid and kebab-cased (ex. 'font-size'), not camel-cased (ex. 'fontSize') like in React, and that property values with dimensions are strings, not numbers with implicit 'px' units. |
 <!-- end-doc-gen -->
@@ -213,8 +251,8 @@ issue](https://github.com/solidjs-community/eslint-plugin-solid/issues/new/choos
 
 ## Versioning
 
-Pre-1.0.0, the rules and the `recommended` and `typescript` configuations will be
-stable across patch (`0.0.x`) versions, but may change across minor (`0.x`) versions.
+Pre-1.0.0, the rules and the `recommended`, `typescript`, `v2`, and `v2-strict` configurations
+will be stable across patch (`0.0.x`) versions, but may change across minor (`0.x`) versions.
 If you want to pin a minor version, use a tilde in your `package.json`.
 
 <!-- doc-gen TILDE -->

--- a/packages/eslint-plugin-solid/README.md
+++ b/packages/eslint-plugin-solid/README.md
@@ -257,7 +257,7 @@ If you want to pin a minor version, use a tilde in your `package.json`.
 
 <!-- doc-gen TILDE -->
 ```diff
-- "eslint-plugin-solid": "^0.15.0"
-+ "eslint-plugin-solid": "~0.15.0"
+- "eslint-plugin-solid": "^0.16.0"
++ "eslint-plugin-solid": "~0.16.0"
 ```
 <!-- end-doc-gen -->

--- a/packages/eslint-plugin-solid/docs/event-handlers.md
+++ b/packages/eslint-plugin-solid/docs/event-handlers.md
@@ -93,6 +93,22 @@ let el = <div {...{ onClick: handleClick }} />;
 const handleClick = () => 42;
 let el = <div onClick={handleClick} />;
 
+let el = <div onclick={() => setCount(1)} />;
+// after eslint --fix:
+let el = <div onClick={() => setCount(1)} />;
+
+let el = <div ondoubleclick={() => {}} />;
+// after eslint --fix:
+let el = <div onDblClick={() => {}} />;
+
+let el = <div onfoobar={() => {}} />;
+
+let el = <div onClick="alert('hi')" />;
+
+let el = <div onDoubleClick={() => {}} />;
+// after eslint --fix:
+let el = <div onDblClick={() => {}} />;
+
 ```
 
 ### Valid Examples
@@ -132,6 +148,12 @@ let el = <div onclick={onclick} />;
 
 /* eslint solid/event-handlers: ["error", { "ignoreCase": true }] */
 let el = <div only={only} />;
+
+let el = <button onClick={() => setCount(count() + 1)} />;
+
+let el = <div onclick="alert('hi')" />;
+
+let el = <div only="static" />;
 
 ```
 <!-- end-doc-gen -->

--- a/packages/eslint-plugin-solid/docs/imports.md
+++ b/packages/eslint-plugin-solid/docs/imports.md
@@ -54,6 +54,14 @@ import { render, createEffect } from "solid-js";
 import { render } from "solid-js/web";
 import { createEffect } from "solid-js";
 
+import { render } from "solid-js";
+// after eslint --fix:
+import { render } from "@solidjs/web";
+
+import { createSignal } from "@solidjs/web";
+// after eslint --fix:
+import { createSignal } from "solid-js";
+
 ```
 
 ### Valid Examples
@@ -79,6 +87,12 @@ Solid.render();
 
 import type { Component, JSX } from "solid-js";
 import type { Store } from "solid-js/store";
+
+import { createSignal, createStore, reconcile, merge } from "solid-js";
+
+import { render, Portal, Dynamic, isServer } from "@solidjs/web";
+
+import { createStore } from "solid-js/store";
 
 ```
 <!-- end-doc-gen -->

--- a/packages/eslint-plugin-solid/docs/jsx-no-undef.md
+++ b/packages/eslint-plugin-solid/docs/jsx-no-undef.md
@@ -136,6 +136,18 @@ import { For } from "solid-js";
 import X from "x"; // attached comment
 let el = <For each={items}>{(item) => item.name}</For>;
 
+let el = <Repeat count={5}>{(i) => <div>{i}</div>}</Repeat>;
+// after eslint --fix:
+import { Repeat } from "solid-js";
+let el = <Repeat count={5}>{(i) => <div>{i}</div>}</Repeat>;
+
+let el = <Loading fallback={spinner}>{content}</Loading>;
+// after eslint --fix:
+import { Loading } from "solid-js";
+let el = <Loading fallback={spinner}>{content}</Loading>;
+
+let el = <Index each={items} />;
+
 ```
 
 ### Valid Examples

--- a/packages/eslint-plugin-solid/docs/no-accessor-as-prop.md
+++ b/packages/eslint-plugin-solid/docs/no-accessor-as-prop.md
@@ -1,0 +1,71 @@
+<!-- doc-gen HEADER -->
+# solid/no-accessor-as-prop
+Disallow passing uncalled signal accessors or other functions as value-typed DOM element attributes.
+This rule is **off** by default.
+
+[View source](../src/rules/no-accessor-as-prop.ts) · [View tests](../test/rules/no-accessor-as-prop.test.ts)
+<!-- end-doc-gen -->
+
+Passing an uncalled signal accessor as a value-typed DOM attribute (`<div title={count} />`) silently sets the attribute to a stringified function. TypeScript has flagged this since Solid 1.7, but the error is a cryptic assignability failure, and many pipelines never run `tsc` (Vite builds don't typecheck). This rule is the enforcement and translation layer: it fires on the same span with a message that states the fix (`count` → `count()`).
+
+Unlike `solid/reactivity`'s signal tracing, any expression that statically resolves to a function fires here — including plain helper functions — and the rule keeps working when the `reactivity` mega-rule is disabled. Event handlers (`onClick`), `ref`, `children`, namespaced attributes, components, and custom elements are all exempt, since functions are legitimate values there.
+
+This rule is enabled as an error in the `v2` and `v2-strict` configs.
+
+<!-- doc-gen OPTIONS -->
+<!-- end-doc-gen -->
+
+<!-- doc-gen CASES -->
+## Tests
+
+### Invalid Examples
+
+These snippets cause lint errors.
+
+```js
+import { createSignal } from "solid-js";
+const [count] = createSignal(0);
+let el = <div title={count} />;
+
+import { createMemo } from "solid-js";
+const label = createMemo(() => "hi");
+let el = <input value={label} />;
+
+const getTitle = () => "hello";
+let el = <div title={getTitle} />;
+
+let el = <div title={() => "hello"} />;
+
+```
+
+### Valid Examples
+
+These snippets don't cause lint errors.
+
+```js
+import { createSignal } from "solid-js";
+const [count] = createSignal(0);
+let el = <div title={count()} />;
+
+import { createMemo } from "solid-js";
+const label = createMemo(() => "hi");
+let el = <input value={label()} />;
+
+import { createSignal } from "solid-js";
+const [count, setCount] = createSignal(0);
+let el = <button onClick={() => setCount(count() + 1)} ref={register} />;
+
+import { createSignal } from "solid-js";
+const [count] = createSignal(0);
+let el = <Counter value={count} />;
+
+import { createSignal } from "solid-js";
+const [count] = createSignal(0);
+let el = <my-element value={count} />;
+
+let el = <div title={title} />;
+
+let el = <div title={"hello"} tabindex={0} />;
+
+```
+<!-- end-doc-gen -->

--- a/packages/eslint-plugin-solid/docs/no-module-scope-reactive-primitive.md
+++ b/packages/eslint-plugin-solid/docs/no-module-scope-reactive-primitive.md
@@ -1,0 +1,61 @@
+<!-- doc-gen HEADER -->
+# solid/no-module-scope-reactive-primitive
+Disallow reactive primitives at module scope, where state is shared across SSR requests.
+This rule is **off** by default.
+
+[View source](../src/rules/no-module-scope-reactive-primitive.ts) · [View tests](../test/rules/no-module-scope-reactive-primitive.test.ts)
+<!-- end-doc-gen -->
+
+Reactive state created at module scope is shared across every request when server rendering, leaking one user's state into another's response. This is a valid pattern in client-only apps — which is why this rule lives only in the `v2-strict` config.
+
+Create reactive state inside a component or provider instead. If module-level state is intentional (a client-only global store), wrap it in `createRoot`, which both documents the intent and gives the state an owner; the rule does not flag primitives created inside any function, including `createRoot` callbacks.
+
+This rule is enabled as an error in the `v2-strict` config only.
+
+<!-- doc-gen OPTIONS -->
+<!-- end-doc-gen -->
+
+<!-- doc-gen CASES -->
+## Tests
+
+### Invalid Examples
+
+These snippets cause lint errors.
+
+```js
+import { createSignal } from "solid-js";
+const [count, setCount] = createSignal(0);
+
+import { createStore } from "solid-js";
+export const [state, setState] = createStore({ user: null });
+
+import { createMemo } from "solid-js";
+const doubled = createMemo(() => count() * 2);
+
+import { createEffect } from "solid-js";
+createEffect(count, (c) => console.log(c));
+
+```
+
+### Valid Examples
+
+These snippets don't cause lint errors.
+
+```js
+import { createSignal } from "solid-js";
+function Counter() {
+  const [count, setCount] = createSignal(0);
+  return <div>{count()}</div>;
+}
+
+import { createStore } from "solid-js";
+export function createTodos() {
+  const [todos, setTodos] = createStore([]);
+  return [todos, setTodos];
+}
+
+import { createRoot, createSignal } from "solid-js";
+const counter = createRoot(() => createSignal(0));
+
+```
+<!-- end-doc-gen -->

--- a/packages/eslint-plugin-solid/docs/no-react-deps.md
+++ b/packages/eslint-plugin-solid/docs/no-react-deps.md
@@ -96,5 +96,7 @@ const args = [
 ];
 createEffect(...args);
 
+createEffect(() => console.log(signal()), [signal]);
+
 ```
 <!-- end-doc-gen -->

--- a/packages/eslint-plugin-solid/docs/no-restated-default-options.md
+++ b/packages/eslint-plugin-solid/docs/no-restated-default-options.md
@@ -1,0 +1,102 @@
+<!-- doc-gen HEADER -->
+# solid/no-restated-default-options
+Disallow restating a prop or option value that is already the default.
+This rule is **off** by default.
+
+[View source](../src/rules/no-restated-default-options.ts) · [View tests](../test/rules/no-restated-default-options.test.ts)
+<!-- end-doc-gen -->
+
+Explicitly passing a prop value that is already the default (`<For keyed={true}>`, `<Show keyed={false}>`) is noise that AI-generated code produces constantly. This rule removes it, in the same opt-in stylistic category as typescript-eslint's `no-unnecessary-type-arguments` or ESLint core's `no-useless-rename`.
+
+Defaults are verified against the Solid 2.0 source: `<For>` is keyed by default; `<Show>` and `<Match>` are non-keyed by default.
+
+This rule is enabled as an error in the `v2-strict` config only.
+
+<!-- doc-gen OPTIONS -->
+<!-- end-doc-gen -->
+
+<!-- doc-gen CASES -->
+## Tests
+
+### Invalid Examples
+
+These snippets cause lint errors, and all of them can be auto-fixed.
+
+```js
+let el = (
+  <For each={items()} keyed={true}>
+    {(item) => <div />}
+  </For>
+);
+// after eslint --fix:
+let el = <For each={items()}>{(item) => <div />}</For>;
+
+let el = (
+  <For each={items()} keyed>
+    {(item) => <div />}
+  </For>
+);
+// after eslint --fix:
+let el = <For each={items()}>{(item) => <div />}</For>;
+
+let el = (
+  <Show when={user()} keyed={false}>
+    <div />
+  </Show>
+);
+// after eslint --fix:
+let el = (
+  <Show when={user()}>
+    <div />
+  </Show>
+);
+
+let el = (
+  <Match when={cond()} keyed={false}>
+    <div />
+  </Match>
+);
+// after eslint --fix:
+let el = (
+  <Match when={cond()}>
+    <div />
+  </Match>
+);
+
+```
+
+### Valid Examples
+
+These snippets don't cause lint errors.
+
+```js
+let el = (
+  <For each={items()} keyed={false}>
+    {(item) => <div />}
+  </For>
+);
+
+let el = (
+  <Show when={user()} keyed>
+    {(u) => <div />}
+  </Show>
+);
+
+let el = (
+  <For each={items()} keyed={rowKey}>
+    {(item) => <div />}
+  </For>
+);
+
+let el = <For each={items()}>{(item) => <div />}</For>;
+
+let el = (
+  <Show when={user()}>
+    <div />
+  </Show>
+);
+
+let el = <Grid keyed={true} />;
+
+```
+<!-- end-doc-gen -->

--- a/packages/eslint-plugin-solid/docs/no-single-arg-create-effect.md
+++ b/packages/eslint-plugin-solid/docs/no-single-arg-create-effect.md
@@ -1,0 +1,63 @@
+<!-- doc-gen HEADER -->
+# solid/no-single-arg-create-effect
+Require the two-argument `createEffect(compute, effect)` form used by Solid 2.0.
+This rule is **off** by default.
+
+[View source](../src/rules/no-single-arg-create-effect.ts) · [View tests](../test/rules/no-single-arg-create-effect.test.ts)
+<!-- end-doc-gen -->
+
+Solid 2.0 splits effects into a tracked compute function and an untracked effect function: `createEffect(compute, effect)`. The single-argument 1.x form is the most commonly reproduced mistake in AI-generated Solid 2.0 code. TypeScript types the 1.x form as `never` through a deprecated overload — which produces no compile error on a bare statement call — and the runtime only throws in dev mode. This rule is the build-time hard stop.
+
+```js
+// Solid 1.x
+createEffect(() => console.log(count()));
+
+// Solid 2.0
+createEffect(() => count(), (value) => console.log(value));
+```
+
+For a derived value, use `createMemo`. For a one-shot side effect at setup time, just call the function directly.
+
+This rule is enabled as an error in the `v2` and `v2-strict` configs.
+
+<!-- doc-gen OPTIONS -->
+<!-- end-doc-gen -->
+
+<!-- doc-gen CASES -->
+## Tests
+
+### Invalid Examples
+
+These snippets cause lint errors.
+
+```js
+import { createEffect } from "solid-js";
+createEffect(() => console.log(count()));
+
+import { createRenderEffect } from "solid-js";
+createRenderEffect(() => update(count()));
+
+```
+
+### Valid Examples
+
+These snippets don't cause lint errors.
+
+```js
+import { createEffect } from "solid-js";
+createEffect(
+  () => count(),
+  (value) => console.log(value)
+);
+
+import { createEffect } from "solid-js";
+createEffect(count, (value) => console.log(value), { name: "logger" });
+
+import { createRenderEffect } from "solid-js";
+createRenderEffect(
+  () => count(),
+  (value) => update(value)
+);
+
+```
+<!-- end-doc-gen -->

--- a/packages/eslint-plugin-solid/docs/no-unknown-namespaces.md
+++ b/packages/eslint-plugin-solid/docs/no-unknown-namespaces.md
@@ -45,6 +45,16 @@ let el = <Box attr:foo="bar" />;
 
 let el = <Box foo:boo={null} />;
 
+let el = <div on:click={handler} />;
+
+let el = <div use:X={null} />;
+
+let el = <div attr:title="title" />;
+
+let el = <div bool:disabled={cond()} />;
+
+let el = <div oncapture:click={handler} />;
+
 ```
 
 ### Valid Examples
@@ -85,6 +95,21 @@ let el = (
     foo:bar="http://www.w3.org/1999/xlink"
   />
 );
+
+let el = <div foo:boo="literal" />;
+
+let el = <div prop:scrollTop="0px" />;
+
+let el = <div class:mt-10 style:width="100%" />;
+
+let el = (
+  <svg xmlns:xlink="http://www.w3.org/1999/xlink">
+    <use xlink:href="#a" />
+  </svg>
+);
+
+/* eslint solid/no-unknown-namespaces: ["error", { "allowedNamespaces": ["use"] }] */
+let el = <div use:X={null} />;
 
 ```
 <!-- end-doc-gen -->

--- a/packages/eslint-plugin-solid/docs/prefer-onSettled-for-side-effects.md
+++ b/packages/eslint-plugin-solid/docs/prefer-onSettled-for-side-effects.md
@@ -1,0 +1,86 @@
+<!-- doc-gen HEADER -->
+# solid/prefer-onSettled-for-side-effects
+Enforce running side-effectful setup (timers, global listeners, observers) inside `onSettled` instead of the component body.
+This rule is **off** by default.
+
+[View source](../src/rules/prefer-onSettled-for-side-effects.ts) · [View tests](../test/rules/prefer-onSettled-for-side-effects.test.ts)
+<!-- end-doc-gen -->
+
+Side-effectful setup in a component body — timers, global event listeners, observers — runs during component setup: on the server during SSR, and on the client before the DOM has settled. `onSettled` (the 2.0 equivalent of `onMount`) runs client-side at the right time and can return a cleanup function.
+
+`onCleanup` itself is never flagged. It is legitimate and lower-overhead than an `onSettled` return-cleanup; a paired `onCleanup` is a symptom of setup work that belongs in `onSettled`, not the offense. The rule triggers only on a short list of recognized side-effectful calls (`setInterval`/`setTimeout`, `window`/`document` `addEventListener`, `new *Observer`) made directly in a component body — the same calls inside `onSettled`, effects, or event handlers are fine.
+
+This rule is a warning in the `v2-strict` config only.
+
+<!-- doc-gen OPTIONS -->
+<!-- end-doc-gen -->
+
+<!-- doc-gen CASES -->
+## Tests
+
+### Invalid Examples
+
+These snippets cause lint errors.
+
+```js
+function Timer() {
+  const timer = setInterval(tick, 1000);
+  return <div />;
+}
+
+import { onCleanup } from "solid-js";
+function App() {
+  window.addEventListener("resize", onResize);
+  onCleanup(() => window.removeEventListener("resize", onResize));
+  return <div />;
+}
+
+const App = () => {
+  const observer = new ResizeObserver(callback);
+  return <div />;
+};
+
+const Widget = () => {
+  document.addEventListener("keydown", onKey);
+  return <div />;
+};
+
+```
+
+### Valid Examples
+
+These snippets don't cause lint errors.
+
+```js
+import { onSettled } from "solid-js";
+function Timer() {
+  onSettled(() => {
+    const timer = setInterval(tick, 1000);
+    return () => clearInterval(timer);
+  });
+  return <div />;
+}
+
+function App() {
+  const start = () => setInterval(tick, 1000);
+  return <button onClick={start} />;
+}
+
+function schedulePoll() {
+  setInterval(poll, 5000);
+}
+
+import { onCleanup } from "solid-js";
+function App() {
+  onCleanup(() => subscription.dispose());
+  return <div />;
+}
+
+function App() {
+  let el;
+  el.addEventListener("click", handler);
+  return <div />;
+}
+
+```
+<!-- end-doc-gen -->

--- a/packages/eslint-plugin-solid/docs/prefer-structured-class.md
+++ b/packages/eslint-plugin-solid/docs/prefer-structured-class.md
@@ -1,0 +1,58 @@
+<!-- doc-gen HEADER -->
+# solid/prefer-structured-class
+Enforce using the structured array/object forms of the `class` prop over manually-built class strings.
+This rule is **off** by default.
+
+[View source](../src/rules/prefer-structured-class.ts) · [View tests](../test/rules/prefer-structured-class.test.ts)
+<!-- end-doc-gen -->
+
+In Solid 2.0, the `class` prop accepts structured values natively: `ClassValue = string | number | boolean | null | undefined | Record<string, boolean> | ClassValue[]`. Solid toggles only the affected classes when a structured value changes.
+
+Manually building class strings — concatenation with conditionals, template literals with reactive expressions, `.filter(Boolean).join(" ")` — is the React/classnames reflex. It still works (a string is a valid `ClassValue`), but it re-runs the whole expression and rewrites the whole attribute on every change. This rule nudges toward either structured form; the object form and the array form are both good, and the rule imposes no preference between them.
+
+Static strings and plain interpolation (`` class={`btn-${kind}`} ``) are untouched. Simple binary cases get a suggestion fix.
+
+This rule is a warning in the `v2` config and an error in `v2-strict`.
+
+<!-- doc-gen OPTIONS -->
+<!-- end-doc-gen -->
+
+<!-- doc-gen CASES -->
+## Tests
+
+### Invalid Examples
+
+These snippets cause lint errors.
+
+```js
+let el = <div class={"btn " + (active() ? "active" : "")} />;
+
+let el = <div class={`btn ${active() ? "active" : ""}`} />;
+
+let el = <div class={[base, active() && "on"].filter(Boolean).join(" ")} />;
+
+let el = <div class={"btn " + variant() + " large"} />;
+
+```
+
+### Valid Examples
+
+These snippets don't cause lint errors.
+
+```js
+let el = <div class={["btn", { active: active() }]} />;
+
+let el = <div class={{ btn: true, active: active() }} />;
+
+let el = <div class="btn primary" />;
+
+let el = <div class={"btn"} />;
+
+let el = <div class={`btn-${kind}`} />;
+
+let el = <div class={"btn" + "-primary"} />;
+
+let el = <div title={"a " + (b() ? "c" : "")} />;
+
+```
+<!-- end-doc-gen -->

--- a/packages/eslint-plugin-solid/docs/removed-api.md
+++ b/packages/eslint-plugin-solid/docs/removed-api.md
@@ -1,0 +1,105 @@
+<!-- doc-gen HEADER -->
+# solid/removed-api
+Disallow Solid 1.x APIs that were removed or renamed in Solid 2.0, with migration guidance.
+This rule is **off** by default.
+
+[View source](../src/rules/removed-api.ts) · [View tests](../test/rules/removed-api.test.ts)
+<!-- end-doc-gen -->
+
+This rule flags Solid 1.x APIs that were removed or renamed in Solid 2.0. Mechanical renames (`onMount` → `onSettled`, `batch` → `flush`, `mergeProps` → `merge`, `unwrap` → `snapshot`, `equalFn` → `isEqual`, `getListener` → `getObserver`) are auto-fixed, including all references. APIs whose replacement requires a structural rewrite (`createResource`, `on`, `Suspense`, `produce`, etc.) get a prescriptive message describing the 2.0 way instead.
+
+It also handles the module moves: `"solid-js/store"` exports now live in core `"solid-js"`, `"solid-js/web"` became the `"@solidjs/web"` package, and the `classList` prop was removed in favor of `class`, which accepts the same object form natively.
+
+This rule is enabled as an error in the `v2` and `v2-strict` configs. It is not intended for Solid 1.x projects.
+
+<!-- doc-gen OPTIONS -->
+<!-- end-doc-gen -->
+
+<!-- doc-gen CASES -->
+## Tests
+
+### Invalid Examples
+
+These snippets cause lint errors, and some can be auto-fixed.
+
+```js
+import { onMount } from "solid-js";
+onMount(() => console.log("hi"));
+// after eslint --fix:
+import { onSettled } from "solid-js";
+onSettled(() => console.log("hi"));
+
+import { batch } from "solid-js";
+batch(() => update());
+// after eslint --fix:
+import { flush } from "solid-js";
+flush(() => update());
+
+import { mergeProps } from "solid-js";
+const props2 = mergeProps({ a: 1 }, props);
+// after eslint --fix:
+import { merge } from "solid-js";
+const props2 = merge({ a: 1 }, props);
+
+import { onMount as om } from "solid-js";
+om(() => {});
+// after eslint --fix:
+import { onSettled as om } from "solid-js";
+om(() => {});
+
+import { createResource } from "solid-js";
+
+import { on, useTransition } from "solid-js";
+
+import { Index, Suspense, ErrorBoundary } from "solid-js";
+
+import { render } from "solid-js/web";
+// after eslint --fix:
+import { render } from "@solidjs/web";
+
+import { createStore } from "solid-js/store";
+// after eslint --fix:
+import { createStore } from "solid-js";
+
+import { createStore, produce } from "solid-js/store";
+
+let el = <div classList={{ active: isActive() }} />;
+// after eslint --fix:
+let el = <div class={{ active: isActive() }} />;
+
+let el = <div class="btn" classList={{ active: isActive() }} />;
+
+```
+
+### Valid Examples
+
+These snippets don't cause lint errors.
+
+```js
+import { createSignal, createMemo, createEffect } from "solid-js";
+
+import { merge, omit, flush, snapshot, isEqual, onSettled } from "solid-js";
+
+import {
+  For,
+  Repeat,
+  Show,
+  Switch,
+  Match,
+  Errored,
+  Loading,
+  Reveal,
+} from "solid-js";
+
+import { createStore, reconcile } from "solid-js";
+
+import { render, Portal, Dynamic } from "@solidjs/web";
+
+import { something } from "somewhere/else";
+
+let el = <div class={{ active: true }} />;
+
+let el = <div class="btn" />;
+
+```
+<!-- end-doc-gen -->

--- a/packages/eslint-plugin-solid/package.json
+++ b/packages/eslint-plugin-solid/package.json
@@ -37,6 +37,22 @@
       "import": "./dist/configs/typescript.mjs",
       "require": "./dist/configs/typescript.js"
     },
+    "./configs/v2": {
+      "types": {
+        "import": "./dist/configs/v2.d.mts",
+        "require": "./dist/configs/v2.d.ts"
+      },
+      "import": "./dist/configs/v2.mjs",
+      "require": "./dist/configs/v2.js"
+    },
+    "./configs/v2-strict": {
+      "types": {
+        "import": "./dist/configs/v2-strict.d.mts",
+        "require": "./dist/configs/v2-strict.d.ts"
+      },
+      "import": "./dist/configs/v2-strict.mjs",
+      "require": "./dist/configs/v2-strict.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "dist/index.js",

--- a/packages/eslint-plugin-solid/package.json
+++ b/packages/eslint-plugin-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-solid",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Solid-specific linting rules for ESLint.",
   "keywords": [
     "eslint",

--- a/packages/eslint-plugin-solid/scripts/docs.mts
+++ b/packages/eslint-plugin-solid/scripts/docs.mts
@@ -15,12 +15,14 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const { rules, configs } = plugin;
 
+const recommendedRules: Record<string, unknown> = configs.recommended.rules;
+
 const ruleTableRows = (Object.keys(rules) as Array<keyof typeof rules & string>)
   .sort()
   .map((id) => {
     const { fixable, docs } = rules[id].meta;
     return [
-      configs.recommended.rules[`solid/${id}`] ? "✔" : "",
+      recommendedRules[`solid/${id}`] ? "✔" : "",
       fixable ? "🔧" : "",
       `[solid/${id}](/packages/eslint-plugin-solid/docs/${id}.md)`,
       docs?.description,

--- a/packages/eslint-plugin-solid/src/configs/v2-strict.ts
+++ b/packages/eslint-plugin-solid/src/configs/v2-strict.ts
@@ -1,0 +1,26 @@
+import type { TSESLint } from "@typescript-eslint/utils";
+
+import v2 from "./v2";
+
+// Everything in the v2 config, plus opinionated rules that are valid patterns
+// in some apps (e.g. client-only) but hazards in others. Intended for teams
+// that want the plugin's strongest opinions.
+const v2Strict = {
+  plugins: v2.plugins,
+  languageOptions: v2.languageOptions,
+  settings: v2.settings,
+  rules: {
+    ...v2.rules,
+    // module-scope reactive state is shared across SSR requests
+    "solid/no-module-scope-reactive-primitive": 2,
+    // side-effectful setup in component bodies belongs in onSettled;
+    // warn-level because detection is a heuristic over a known-call list
+    "solid/prefer-onSettled-for-side-effects": 1,
+    // restating default prop/option values is noise
+    "solid/no-restated-default-options": 2,
+    // graduate the class-string heuristic to an error
+    "solid/prefer-structured-class": 2,
+  },
+} satisfies TSESLint.FlatConfig.Config;
+
+export = v2Strict;

--- a/packages/eslint-plugin-solid/src/configs/v2.ts
+++ b/packages/eslint-plugin-solid/src/configs/v2.ts
@@ -1,0 +1,48 @@
+import type { TSESLint } from "@typescript-eslint/utils";
+
+import { plugin } from "../plugin";
+import recommended from "./recommended";
+
+// The Solid 2.0 config. Sets `settings.solid.version: 2`, which switches
+// version-aware rules (reactivity, imports, no-unknown-namespaces,
+// event-handlers, jsx-no-undef) into strict 2.0 semantics, and enables the
+// 2.0-specific rules. Errors are reserved for near-certain bugs; heuristics
+// stay warnings. This is the config the official templates ship.
+const v2 = {
+  plugins: {
+    solid: plugin,
+  },
+  languageOptions: {
+    sourceType: "module",
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+  settings: {
+    solid: { version: 2 },
+  },
+  rules: {
+    ...recommended.rules,
+    // 1.x APIs that no longer exist; prescriptive migration guidance
+    "solid/removed-api": 2,
+    // 2.0 requires the split createEffect(compute, effect) form
+    "solid/no-single-arg-create-effect": 2,
+    // uncalled accessors as DOM attributes render stringified functions
+    "solid/no-accessor-as-prop": 2,
+    // manual class-string building works but defeats granular class toggling
+    "solid/prefer-structured-class": 1,
+    // graduated from style to correctness in 2.0: only camelCase `onClick` is
+    // an event handler; lowercase forms are literal attributes
+    "solid/event-handlers": 2,
+    // className/htmlFor pass through as literal attributes the DOM ignores
+    "solid/no-react-specific-props": 2,
+    // premise no longer exists in 2.0 (rule also self-gates on version)
+    "solid/no-react-deps": 0,
+    // anti-advice in 2.0: classList was removed in favor of class objects/arrays
+    "solid/prefer-classlist": 0,
+  },
+} satisfies TSESLint.FlatConfig.Config;
+
+export = v2;

--- a/packages/eslint-plugin-solid/src/index.ts
+++ b/packages/eslint-plugin-solid/src/index.ts
@@ -9,12 +9,16 @@ import type { TSESLint } from "@typescript-eslint/utils";
 import { plugin } from "./plugin";
 import recommendedConfig from "./configs/recommended";
 import typescriptConfig from "./configs/typescript";
+import v2Config from "./configs/v2";
+import v2StrictConfig from "./configs/v2-strict";
 
 const pluginWithConfigs = {
   ...plugin,
   configs: {
     recommended: recommendedConfig,
     typescript: typescriptConfig,
+    v2: v2Config,
+    "v2-strict": v2StrictConfig,
     // aliases kept for compatibility with the 0.14.x flat config names
     "flat/recommended": recommendedConfig,
     "flat/typescript": typescriptConfig,

--- a/packages/eslint-plugin-solid/src/plugin.ts
+++ b/packages/eslint-plugin-solid/src/plugin.ts
@@ -13,16 +13,23 @@ import jsxNoDuplicateProps from "./rules/jsx-no-duplicate-props";
 import jsxNoScriptUrl from "./rules/jsx-no-script-url";
 import jsxNoUndef from "./rules/jsx-no-undef";
 import jsxUsesVars from "./rules/jsx-uses-vars";
+import noAccessorAsProp from "./rules/no-accessor-as-prop";
 import noDestructure from "./rules/no-destructure";
 import noInnerHTML from "./rules/no-innerhtml";
+import noModuleScopeReactivePrimitive from "./rules/no-module-scope-reactive-primitive";
 import noProxyApis from "./rules/no-proxy-apis";
 import noReactDeps from "./rules/no-react-deps";
 import noReactSpecificProps from "./rules/no-react-specific-props";
+import noRestatedDefaultOptions from "./rules/no-restated-default-options";
+import noSingleArgCreateEffect from "./rules/no-single-arg-create-effect";
 import noUnknownNamespaces from "./rules/no-unknown-namespaces";
 import preferClasslist from "./rules/prefer-classlist";
 import preferFor from "./rules/prefer-for";
+import preferOnSettledForSideEffects from "./rules/prefer-onSettled-for-side-effects";
 import preferShow from "./rules/prefer-show";
+import preferStructuredClass from "./rules/prefer-structured-class";
 import reactivity from "./rules/reactivity";
+import removedApi from "./rules/removed-api";
 import selfClosingComp from "./rules/self-closing-comp";
 import styleProp from "./rules/style-prop";
 import noArrayHandlers from "./rules/no-array-handlers";
@@ -41,16 +48,23 @@ const allRules = {
   "jsx-no-undef": jsxNoUndef,
   "jsx-no-script-url": jsxNoScriptUrl,
   "jsx-uses-vars": jsxUsesVars,
+  "no-accessor-as-prop": noAccessorAsProp,
   "no-destructure": noDestructure,
   "no-innerhtml": noInnerHTML,
+  "no-module-scope-reactive-primitive": noModuleScopeReactivePrimitive,
   "no-proxy-apis": noProxyApis,
   "no-react-deps": noReactDeps,
   "no-react-specific-props": noReactSpecificProps,
+  "no-restated-default-options": noRestatedDefaultOptions,
+  "no-single-arg-create-effect": noSingleArgCreateEffect,
   "no-unknown-namespaces": noUnknownNamespaces,
   "prefer-classlist": preferClasslist,
   "prefer-for": preferFor,
+  "prefer-onSettled-for-side-effects": preferOnSettledForSideEffects,
   "prefer-show": preferShow,
+  "prefer-structured-class": preferStructuredClass,
   reactivity,
+  "removed-api": removedApi,
   "self-closing-comp": selfClosingComp,
   "style-prop": styleProp,
   "no-array-handlers": noArrayHandlers,

--- a/packages/eslint-plugin-solid/src/rules/event-handlers.ts
+++ b/packages/eslint-plugin-solid/src/rules/event-handlers.ts
@@ -7,7 +7,7 @@
 import type { TSESLint } from "@typescript-eslint/utils";
 
 import { TSESTree as T, ESLintUtils, ASTUtils } from "@typescript-eslint/utils";
-import { isDOMElementName } from "../utils";
+import { isDOMElementName, isSolidV2 } from "../utils";
 import { getScope, getSourceCode } from "../compat";
 
 const createRule = ESLintUtils.RuleCreator.withoutDocs;
@@ -107,7 +107,9 @@ type MessageIds =
   | "make-handler"
   | "make-attr"
   | "detected-attr"
-  | "spread-handler";
+  | "spread-handler"
+  | "lowercase-attribute-v2"
+  | "static-handler-v2";
 type Options = [{ ignoreCase?: boolean; warnOnSpread?: boolean }?];
 
 export default createRule<Options, MessageIds>({
@@ -152,11 +154,16 @@ export default createRule<Options, MessageIds>({
       "make-attr": "Change the {{name}} prop to {{attrName}}.",
       "spread-handler":
         "The {{name}} prop should be added as a JSX attribute, not spread in. Solid doesn't add listeners when spreading into JSX.",
+      "lowercase-attribute-v2":
+        "In Solid 2.0, {{name}} is a literal attribute, not an event handler — this listener will never fire. Rename it to {{fixedName}}.",
+      "static-handler-v2":
+        "In Solid 2.0, {{name}} is an event handler and must be a function, but its value is the static value {{staticValue}}. For a literal attribute, use lowercase {{attrName}}.",
     },
   },
   defaultOptions: [],
   create(context) {
     const sourceCode = getSourceCode(context);
+    const v2 = isSolidV2(context);
 
     return {
       JSXAttribute(node) {
@@ -177,6 +184,86 @@ export default createRule<Options, MessageIds>({
 
         if (!/^on[a-zA-Z]/.test(name)) {
           return; // bail if Solid doesn't consider the prop name an event handler
+        }
+
+        if (v2) {
+          // In Solid 2.0 only the camelCase form (`onClick`) is an event handler;
+          // lowercase names (`onclick`) are literal attributes.
+          const isCamelCase = name[2] === name[2].toUpperCase();
+          const lowercaseName = name.toLowerCase();
+
+          if (isCamelCase) {
+            // Event handler position: a static string/number value is a bug.
+            let camelStaticValue: ReturnType<typeof getStaticValue> = null;
+            if (
+              node.value?.type === "JSXExpressionContainer" &&
+              node.value.expression.type !== "JSXEmptyExpression" &&
+              node.value.expression.type !== "ArrayExpression"
+            ) {
+              camelStaticValue = getStaticValue(node.value.expression, getScope(context, node));
+            }
+            if (node.value === null || node.value?.type === "Literal") {
+              camelStaticValue = { value: node.value !== null ? node.value.value : true };
+            }
+            if (
+              camelStaticValue !== null &&
+              (typeof camelStaticValue.value === "string" ||
+                typeof camelStaticValue.value === "number" ||
+                typeof camelStaticValue.value === "boolean")
+            ) {
+              context.report({
+                node,
+                messageId: "static-handler-v2",
+                data: { name, staticValue: camelStaticValue.value, attrName: lowercaseName },
+              });
+            } else if (isNonstandardEventName(lowercaseName)) {
+              // e.g. onDoubleClick — lowercasing yields no real DOM event, so
+              // the listener would silently never fire.
+              const fixedName = getStandardEventHandlerName(lowercaseName);
+              context.report({
+                node: node.name,
+                messageId: "nonstandard",
+                data: { name, fixedName },
+                fix: (fixer) => fixer.replaceText(node.name, fixedName),
+              });
+            }
+          } else {
+            // Literal attribute position: string values are fine, functions are
+            // a near-certain intended event handler that will never fire.
+            const isStaticAttributeValue =
+              node.value === null ||
+              node.value.type === "Literal" ||
+              (node.value.type === "JSXExpressionContainer" &&
+                node.value.expression.type !== "JSXEmptyExpression" &&
+                node.value.expression.type !== "ArrayExpression" &&
+                getStaticValue(node.value.expression, getScope(context, node)) !== null);
+            if (!isStaticAttributeValue) {
+              const fixedName = isNonstandardEventName(lowercaseName)
+                ? getStandardEventHandlerName(lowercaseName)
+                : isCommonHandlerName(lowercaseName)
+                ? getCommonEventHandlerName(lowercaseName)
+                : `on${name[2].toUpperCase()}${name.slice(3)}`;
+              const known =
+                isNonstandardEventName(lowercaseName) || isCommonHandlerName(lowercaseName);
+              context.report({
+                node: node.name,
+                messageId: "lowercase-attribute-v2",
+                data: { name, fixedName },
+                // Autofix when the event is a known DOM event; suggest otherwise.
+                fix: known ? (fixer) => fixer.replaceText(node.name, fixedName) : undefined,
+                suggest: known
+                  ? undefined
+                  : [
+                      {
+                        messageId: "make-handler",
+                        data: { name, handlerName: fixedName },
+                        fix: (fixer) => fixer.replaceText(node.name, fixedName),
+                      },
+                    ],
+              });
+            }
+          }
+          return;
         }
 
         let staticValue: ReturnType<typeof getStaticValue>;

--- a/packages/eslint-plugin-solid/src/rules/imports.ts
+++ b/packages/eslint-plugin-solid/src/rules/imports.ts
@@ -1,5 +1,5 @@
 import { TSESTree as T, TSESLint, ESLintUtils } from "@typescript-eslint/utils";
-import { appendImports, insertImports, removeSpecifier } from "../utils";
+import { appendImports, insertImports, isSolidV2, removeSpecifier } from "../utils";
 import { getSourceCode } from "../compat";
 
 const createRule = ESLintUtils.RuleCreator.withoutDocs;
@@ -132,8 +132,120 @@ const alternateSourceMap = new Map<string, Source>([
   ["SetStoreFunction", "solid-js"],
 ]);
 
+// ==============
+// Solid 2.0: "solid-js/store" no longer exists (store exports live in core),
+// and "solid-js/web" became the "@solidjs/web" package. When `settings.solid.
+// version` is 2, the rule *requires* the 2.0 locations. Lists verified against
+// the RC source (packages/solid/src/index.ts, packages/solid-web/src/index.ts).
+type SourceV2 = "solid-js" | "@solidjs/web";
+
+const primitiveMapV2 = new Map<string, SourceV2>();
+for (const primitive of [
+  // reactive primitives
+  "createSignal",
+  "createMemo",
+  "createStore",
+  "createEffect",
+  "createRenderEffect",
+  "createProjection",
+  "createOptimistic",
+  "createOptimisticStore",
+  "createReaction",
+  "createRoot",
+  "createOwner",
+  "createContext",
+  "useContext",
+  "children",
+  "lazy",
+  "createUniqueId",
+  "createErrorBoundary",
+  "createLoadingBoundary",
+  "createRevealOrder",
+  // lifecycle and utilities
+  "onCleanup",
+  "onSettled",
+  "untrack",
+  "flush",
+  "merge",
+  "omit",
+  "mapArray",
+  "repeat",
+  "getOwner",
+  "getObserver",
+  "runWithOwner",
+  "isEqual",
+  "isPending",
+  "latest",
+  "action",
+  "reconcile",
+  "snapshot",
+  "resolve",
+  "refresh",
+  "flatten",
+  "deep",
+  "affects",
+  "storePath",
+  "DEV",
+  // control flow components
+  "For",
+  "Repeat",
+  "Show",
+  "Switch",
+  "Match",
+  "Errored",
+  "Loading",
+  "Reveal",
+]) {
+  primitiveMapV2.set(primitive, "solid-js");
+}
+for (const primitive of [
+  "Portal",
+  "Dynamic",
+  "render",
+  "hydrate",
+  "isServer",
+  "renderToString",
+  "renderToStream",
+  "renderToStringAsync",
+  "generateHydrationScript",
+  "HydrationScript",
+]) {
+  primitiveMapV2.set(primitive, "@solidjs/web");
+}
+
+const typeMapV2 = new Map<string, SourceV2>();
+for (const type of [
+  "Signal",
+  "Accessor",
+  "Setter",
+  "Component",
+  "ValidComponent",
+  "ComponentProps",
+  "Context",
+  "JSX",
+  "ResolvedChildren",
+  "Store",
+  "StoreNode",
+  "StoreSetter",
+  "StoreOptions",
+  "SignalOptions",
+  "MemoOptions",
+  "EffectOptions",
+  "Owner",
+]) {
+  typeMapV2.set(type, "solid-js");
+}
+
 const sourceRegex = /^solid-js(?:\/web|\/store)?$/;
 const isSource = (source: string): source is Source => sourceRegex.test(source);
+
+// The legacy "solid-js/store" and "solid-js/web" sources are deliberately
+// excluded here: in v2 mode those modules no longer exist and solid/removed-api
+// owns reporting/rewriting them, so this rule only polices specifier placement
+// between the surviving modules.
+const sourceRegexV2 = /^(?:solid-js|@solidjs\/web)$/;
+const isSourceV2 = (source: string): source is Source | "@solidjs/web" =>
+  sourceRegexV2.test(source);
 
 export default createRule({
   meta: {
@@ -151,15 +263,22 @@ export default createRule({
   },
   defaultOptions: [],
   create(context) {
+    const v2 = isSolidV2(context);
     return {
       ImportDeclaration(node) {
         const source = node.source.value;
-        if (!isSource(source)) return;
+        if (v2 ? !isSourceV2(source) : !isSource(source)) return;
 
         for (const specifier of node.specifiers) {
           if (specifier.type === "ImportSpecifier") {
             const isType = specifier.importKind === "type" || node.importKind === "type";
-            const map = isType ? typeMap : primitiveMap;
+            const map = v2
+              ? isType
+                ? typeMapV2
+                : primitiveMapV2
+              : isType
+              ? typeMap
+              : primitiveMap;
             const importedName =
               specifier.imported.type === "Identifier"
                 ? specifier.imported.name
@@ -168,7 +287,7 @@ export default createRule({
             if (
               correctSource != null &&
               correctSource !== source &&
-              alternateSourceMap.get(importedName) !== source
+              (v2 || alternateSourceMap.get(importedName) !== source)
             ) {
               context.report({
                 node: specifier,
@@ -195,7 +314,9 @@ export default createRule({
                   }
 
                   const firstSolidDeclaration = program.body.find(
-                    (node) => node.type === "ImportDeclaration" && isSource(node.source.value)
+                    (node) =>
+                      node.type === "ImportDeclaration" &&
+                      (v2 ? isSourceV2(node.source.value) : isSource(node.source.value))
                   ) as T.ImportDeclaration | undefined;
                   return [
                     removeSpecifier(fixer, sourceCode, specifier),

--- a/packages/eslint-plugin-solid/src/rules/jsx-no-undef.ts
+++ b/packages/eslint-plugin-solid/src/rules/jsx-no-undef.ts
@@ -7,13 +7,25 @@
 import type { TSESLint } from "@typescript-eslint/utils";
 
 import { TSESTree as T, ESLintUtils } from "@typescript-eslint/utils";
-import { isDOMElementName, formatList, appendImports, insertImports } from "../utils";
+import { isDOMElementName, formatList, appendImports, insertImports, isSolidV2 } from "../utils";
 import { getScope, getSourceCode } from "../compat";
 
 const createRule = ESLintUtils.RuleCreator.withoutDocs;
 
 // Currently all of the control flow components are from 'solid-js'.
 const AUTO_COMPONENTS = ["Show", "For", "Index", "Switch", "Match"];
+// Solid 2.0 control flow components; `Index`, `ErrorBoundary`, `Suspense`, and
+// `SuspenseList` no longer exist (see solid/removed-api).
+const AUTO_COMPONENTS_V2 = [
+  "For",
+  "Repeat",
+  "Show",
+  "Switch",
+  "Match",
+  "Errored",
+  "Loading",
+  "Reveal",
+];
 const SOURCE_MODULE = "solid-js";
 
 /*
@@ -72,6 +84,7 @@ export default createRule<Options, MessageIds>({
     const allowGlobals = context.options[0]?.allowGlobals ?? false;
     const autoImport = context.options[0]?.autoImport !== false;
     const isTypeScriptEnabled = context.options[0]?.typescriptEnabled ?? false;
+    const autoComponents = isSolidV2(context) ? AUTO_COMPONENTS_V2 : AUTO_COMPONENTS;
 
     const missingComponentsSet = new Set<string>();
 
@@ -117,7 +130,7 @@ export default createRule<Options, MessageIds>({
       if (
         isComponent &&
         autoImport &&
-        AUTO_COMPONENTS.includes(node.name) &&
+        autoComponents.includes(node.name) &&
         !missingComponentsSet.has(node.name)
       ) {
         // track which names are undefined

--- a/packages/eslint-plugin-solid/src/rules/no-accessor-as-prop.ts
+++ b/packages/eslint-plugin-solid/src/rules/no-accessor-as-prop.ts
@@ -1,0 +1,147 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
+import { TSESTree as T, ESLintUtils } from "@typescript-eslint/utils";
+import { findVariable } from "../compat";
+import { isDOMElementName, isFunctionNode, trackImports } from "../utils";
+
+const createRule = ESLintUtils.RuleCreator.withoutDocs;
+
+type MessageIds = "accessorAsProp" | "functionAsProp";
+type Options = [];
+
+// Attributes on DOM elements that legitimately accept a function value.
+const FUNCTION_ATTRIBUTES = new Set(["ref", "children"]);
+
+// camelCase `onX` names are event handlers; lowercase `onx` names are literal
+// attributes in Solid 2.0 but are solid/event-handlers' territory — skip both
+// here so a single node never gets two reports.
+const isOnPrefixed = (name: string) => name.length > 2 && name.startsWith("on");
+
+/*
+ * Passing an uncalled signal accessor as a DOM element attribute
+ * (`<div title={count} />`) silently sets the attribute to a stringified
+ * function. TypeScript flags this with a cryptic assignability error that
+ * many pipelines never run (Vite builds don't typecheck); this rule is the
+ * enforcement and translation layer. Unlike solid/reactivity's signal
+ * tracing, any expression that resolves to a function fires here.
+ */
+export default createRule<Options, MessageIds>({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow passing uncalled signal accessors or other functions as value-typed DOM element attributes.",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-accessor-as-prop.md",
+    },
+    hasSuggestions: true,
+    schema: [],
+    messages: {
+      accessorAsProp:
+        "'{{attribute}}' expects a value, but '{{name}}' is a signal accessor — call it: '{{name}}()'.",
+      functionAsProp:
+        "'{{attribute}}' expects a value, but this is a function; it would render as a stringified function. If it derives a value, call it.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const { matchImport, handleImportDeclaration } = trackImports();
+
+    /** Is `id` a signal accessor or plain function we can resolve statically? */
+    const resolveFunctionKind = (id: T.Identifier): "accessor" | "function" | null => {
+      const variable = findVariable(context, id);
+      const def = variable?.defs[0];
+      if (!def) return null;
+
+      if (def.type === "FunctionName") return "function";
+      if (def.type !== "Variable" || !def.node.init) return null;
+
+      const { id: declId, init } = def.node;
+      // const count = () => ...;
+      if (declId.type === "Identifier" && isFunctionNode(init)) return "function";
+      if (init.type !== "CallExpression" || init.callee.type !== "Identifier") return null;
+
+      // const memo = createMemo(...)
+      if (
+        declId.type === "Identifier" &&
+        matchImport(["createMemo", "children"], init.callee.name)
+      ) {
+        return "accessor";
+      }
+      // const [count] = createSignal(...); const [value] = createOptimistic(...)
+      if (
+        declId.type === "ArrayPattern" &&
+        declId.elements[0]?.type === "Identifier" &&
+        declId.elements[0].name === id.name &&
+        matchImport(["createSignal", "createOptimistic"], init.callee.name)
+      ) {
+        return "accessor";
+      }
+      return null;
+    };
+
+    return {
+      ImportDeclaration: handleImportDeclaration,
+      JSXAttribute(node) {
+        // Only plain attributes on native DOM elements; namespaced attributes
+        // and custom elements can legitimately carry unusual values.
+        if (node.name.type !== "JSXIdentifier") return;
+        const attribute = node.name.name;
+        if (FUNCTION_ATTRIBUTES.has(attribute) || isOnPrefixed(attribute)) return;
+
+        const element = node.parent as T.JSXOpeningElement;
+        if (
+          element.name.type !== "JSXIdentifier" ||
+          !isDOMElementName(element.name.name) ||
+          element.name.name.includes("-")
+        ) {
+          return;
+        }
+
+        if (node.value?.type !== "JSXExpressionContainer") return;
+        const expression = node.value.expression;
+
+        if (isFunctionNode(expression)) {
+          context.report({ node: expression, messageId: "functionAsProp", data: { attribute } });
+          return;
+        }
+
+        if (expression.type === "Identifier") {
+          const kind = resolveFunctionKind(expression);
+          if (kind === "accessor") {
+            context.report({
+              node: expression,
+              messageId: "accessorAsProp",
+              data: { attribute, name: expression.name },
+              suggest: [
+                {
+                  messageId: "accessorAsProp",
+                  data: { attribute, name: expression.name },
+                  fix: (fixer) => fixer.insertTextAfter(expression, "()"),
+                },
+              ],
+            });
+          } else if (kind === "function") {
+            context.report({
+              node: expression,
+              messageId: "functionAsProp",
+              data: { attribute },
+              suggest: [
+                {
+                  messageId: "functionAsProp",
+                  data: { attribute },
+                  fix: (fixer) => fixer.insertTextAfter(expression, "()"),
+                },
+              ],
+            });
+          }
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-solid/src/rules/no-module-scope-reactive-primitive.ts
+++ b/packages/eslint-plugin-solid/src/rules/no-module-scope-reactive-primitive.ts
@@ -1,0 +1,69 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
+import { ESLintUtils } from "@typescript-eslint/utils";
+import { findParent, isFunctionNode, trackImports } from "../utils";
+
+const createRule = ESLintUtils.RuleCreator.withoutDocs;
+
+type MessageIds = "moduleScopePrimitive";
+type Options = [];
+
+const REACTIVE_PRIMITIVES = [
+  "createSignal",
+  "createMemo",
+  "createStore",
+  "createEffect",
+  "createRenderEffect",
+  "createOptimistic",
+  "createOptimisticStore",
+  "createProjection",
+];
+
+/*
+ * Reactive state created at module scope is shared across every request when
+ * server rendering, leaking one user's state into another's response. It is a
+ * valid pattern in client-only apps, which is why this rule is only enabled
+ * in the strict config. Wrapping in `createRoot` (or any function) is the
+ * deliberate escape hatch and is not flagged.
+ */
+export default createRule<Options, MessageIds>({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow reactive primitives at module scope, where state is shared across SSR requests.",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-module-scope-reactive-primitive.md",
+    },
+    schema: [],
+    messages: {
+      moduleScopePrimitive:
+        "{{name}} at module scope creates state shared across all SSR requests. Create it inside a component or provider, or wrap it in `createRoot` if module-level state is intentional (client-only).",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const { matchImport, handleImportDeclaration } = trackImports();
+
+    return {
+      ImportDeclaration: handleImportDeclaration,
+      CallExpression(node) {
+        if (node.callee.type !== "Identifier") return;
+        const name = matchImport(REACTIVE_PRIMITIVES, node.callee.name);
+        if (!name) return;
+        if (findParent(node, isFunctionNode) == null) {
+          context.report({
+            node,
+            messageId: "moduleScopePrimitive",
+            data: { name: node.callee.name },
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-solid/src/rules/no-react-deps.ts
+++ b/packages/eslint-plugin-solid/src/rules/no-react-deps.ts
@@ -7,7 +7,7 @@
 import type { TSESLint } from "@typescript-eslint/utils";
 
 import { ESLintUtils } from "@typescript-eslint/utils";
-import { isFunctionNode, trace, trackImports } from "../utils";
+import { isFunctionNode, isSolidV2, trace, trackImports } from "../utils";
 
 const createRule = ESLintUtils.RuleCreator.withoutDocs;
 
@@ -27,6 +27,11 @@ export default createRule({
   },
   defaultOptions: [],
   create(context) {
+    // In Solid 2.0 the second argument of createEffect is the (required) effect
+    // function, so a "dependency array" there is a type and runtime error already;
+    // this rule's premise only exists in 1.x.
+    if (isSolidV2(context)) return {};
+
     /** Tracks imports from 'solid-js', handling aliases. */
     const { matchImport, handleImportDeclaration } = trackImports();
 

--- a/packages/eslint-plugin-solid/src/rules/no-restated-default-options.ts
+++ b/packages/eslint-plugin-solid/src/rules/no-restated-default-options.ts
@@ -1,0 +1,80 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
+import { TSESTree as T, ESLintUtils } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator.withoutDocs;
+
+type MessageIds = "restatedDefault";
+type Options = [];
+
+// Defaults verified against the Solid 2.0 RC source (client/flow.ts):
+// <For> is keyed by default; <Show> and <Match> are non-keyed by default.
+const JSX_PROP_DEFAULTS: Record<string, Record<string, boolean>> = {
+  For: { keyed: true },
+  Show: { keyed: false },
+  Match: { keyed: false },
+};
+
+/*
+ * Explicitly passing a prop's default value is noise that AI-generated code
+ * produces constantly. Same category as typescript-eslint's
+ * no-unnecessary-type-arguments: opt-in, stylistic, autofixable.
+ */
+export default createRule<Options, MessageIds>({
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Disallow restating a prop or option value that is already the default.",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-restated-default-options.md",
+    },
+    fixable: "code",
+    schema: [],
+    messages: {
+      restatedDefault:
+        "Passing `{{prop}}={{{value}}}` restates the default for `<{{component}}>`; omit it.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      JSXAttribute(node) {
+        if (node.name.type !== "JSXIdentifier") return;
+        const element = node.parent as T.JSXOpeningElement;
+        if (element.name.type !== "JSXIdentifier") return;
+
+        const defaults = JSX_PROP_DEFAULTS[element.name.name];
+        if (!defaults) return;
+        const prop = node.name.name;
+        if (!(prop in defaults)) return;
+        const defaultValue = defaults[prop];
+
+        let stated: boolean | null = null;
+        if (node.value == null) {
+          // bare prop, e.g. `<Show keyed>` means true
+          stated = true;
+        } else if (
+          node.value.type === "JSXExpressionContainer" &&
+          node.value.expression.type === "Literal" &&
+          typeof node.value.expression.value === "boolean"
+        ) {
+          stated = node.value.expression.value;
+        }
+
+        if (stated === defaultValue) {
+          context.report({
+            node,
+            messageId: "restatedDefault",
+            data: { prop, value: String(stated), component: element.name.name },
+            fix: (fixer) => fixer.remove(node),
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-solid/src/rules/no-single-arg-create-effect.ts
+++ b/packages/eslint-plugin-solid/src/rules/no-single-arg-create-effect.ts
@@ -1,0 +1,56 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
+import { ESLintUtils } from "@typescript-eslint/utils";
+import { trackImports } from "../utils";
+
+const createRule = ESLintUtils.RuleCreator.withoutDocs;
+
+type MessageIds = "singleArgEffect" | "singleArgRenderEffect";
+type Options = [];
+
+/*
+ * Solid 2.0 splits effects into a tracked compute function and an untracked
+ * effect function: `createEffect(compute, effect)`. The single-argument 1.x
+ * form types as `never` via a deprecated overload — which produces no compile
+ * error on a bare statement call — and only throws at runtime in dev mode.
+ * This rule is the build-time hard stop.
+ */
+export default createRule<Options, MessageIds>({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require the two-argument `createEffect(compute, effect)` form used by Solid 2.0.",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-single-arg-create-effect.md",
+    },
+    schema: [],
+    messages: {
+      singleArgEffect:
+        "In Solid 2.0, createEffect takes separate compute and effect functions: `createEffect(() => signal(), (value) => doWork(value))`. For a derived value use `createMemo`; for a one-shot side effect, just call the function directly.",
+      singleArgRenderEffect:
+        "In Solid 2.0, createRenderEffect takes separate compute and effect functions: `createRenderEffect(() => signal(), (value) => doWork(value))`.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const { matchImport, handleImportDeclaration } = trackImports();
+
+    return {
+      ImportDeclaration: handleImportDeclaration,
+      CallExpression(node) {
+        if (node.callee.type !== "Identifier" || node.arguments.length !== 1) return;
+        if (matchImport("createEffect", node.callee.name)) {
+          context.report({ node, messageId: "singleArgEffect" });
+        } else if (matchImport("createRenderEffect", node.callee.name)) {
+          context.report({ node, messageId: "singleArgRenderEffect" });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-solid/src/rules/no-unknown-namespaces.ts
+++ b/packages/eslint-plugin-solid/src/rules/no-unknown-namespaces.ts
@@ -7,7 +7,7 @@
 import type { TSESLint } from "@typescript-eslint/utils";
 
 import { ESLintUtils, TSESTree as T } from "@typescript-eslint/utils";
-import { isDOMElementName } from "../utils";
+import { isDOMElementName, isSolidV2 } from "../utils";
 
 const createRule = ESLintUtils.RuleCreator.withoutDocs;
 
@@ -15,7 +15,21 @@ const knownNamespaces = ["on", "oncapture", "use", "prop", "attr", "bool"];
 const styleNamespaces = ["style", "class"];
 const otherNamespaces = ["xmlns", "xlink"];
 
-type MessageIds = "unknown" | "style" | "component" | "component-suggest";
+// In Solid 2.0, namespaces are no longer reserved: any colon-name passes
+// through as a literal attribute, and `prop:` is the only special prefix left.
+// The formerly-public 1.x prefixes now silently render literal attributes, so
+// in v2 mode they're flagged as near-certain migration bugs with per-prefix
+// guidance.
+const v2MigrationGuidance: Record<string, string> = {
+  on: "For an event handler, use the camelCase form instead: `onClick`",
+  oncapture:
+    "There is no capture-phase prefix in Solid 2.0; add a capture listener with `addEventListener` in a `ref` if needed",
+  use: "Directives were removed in Solid 2.0; call the function in `ref` instead: `ref={(el) => myDirective(el)}`",
+  attr: "Use the plain attribute name; attributes are the default in Solid 2.0",
+  bool: "Use the plain attribute with a boolean or conditional value",
+};
+
+type MessageIds = "unknown" | "style" | "component" | "component-suggest" | "v2Namespace";
 type Options = [{ allowedNamespaces: Array<string> }?];
 
 export default createRule<Options, MessageIds>({
@@ -53,11 +67,14 @@ export default createRule<Options, MessageIds>({
         "Using the '{{namespace}}:' special prefix is potentially confusing, prefer the '{{namespace}}' prop instead.",
       component: "Namespaced props have no effect on components.",
       "component-suggest": "Replace {{namespace}}:{{name}} with {{name}}.",
+      v2Namespace:
+        "'{{namespace}}:' is not a special prefix in Solid 2.0; this renders a literal '{{namespace}}:{{name}}' attribute. {{guidance}}.",
     },
   },
   defaultOptions: [],
   create(context) {
     const explicitlyAllowedNamespaces = context.options?.[0]?.allowedNamespaces;
+    const v2 = isSolidV2(context);
     return {
       "JSXAttribute > JSXNamespacedName": (node: T.JSXNamespacedName) => {
         const openingElement = node.parent!.parent as T.JSXOpeningElement;
@@ -81,6 +98,21 @@ export default createRule<Options, MessageIds>({
         }
 
         const namespace = node.namespace?.name;
+
+        if (v2) {
+          // In 2.0 any colon-name is a legal literal attribute; only flag the
+          // formerly-special 1.x prefixes, which are near-certain migration bugs.
+          const guidance = v2MigrationGuidance[namespace];
+          if (guidance && !explicitlyAllowedNamespaces?.includes(namespace)) {
+            context.report({
+              node,
+              messageId: "v2Namespace",
+              data: { namespace, name: node.name.name, guidance },
+            });
+          }
+          return;
+        }
+
         if (
           !(
             knownNamespaces.includes(namespace) ||

--- a/packages/eslint-plugin-solid/src/rules/prefer-onSettled-for-side-effects.ts
+++ b/packages/eslint-plugin-solid/src/rules/prefer-onSettled-for-side-effects.ts
@@ -1,0 +1,101 @@
+/**
+ * FIXME: remove this comments and import when below issue is fixed.
+ * This import is necessary for type generation due to a bug in the TypeScript compiler.
+ * See: https://github.com/microsoft/TypeScript/issues/42873
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { TSESLint } from "@typescript-eslint/utils";
+
+import { TSESTree as T, ESLintUtils } from "@typescript-eslint/utils";
+import {
+  findParent,
+  getFunctionName,
+  isFunctionNode,
+  isJSXElementOrFragment,
+  type FunctionNode,
+} from "../utils";
+
+const createRule = ESLintUtils.RuleCreator.withoutDocs;
+
+type MessageIds = "sideEffectInBody";
+type Options = [];
+
+const TIMER_CALLS = new Set(["setInterval", "setTimeout"]);
+const OBSERVER_CONSTRUCTORS = new Set([
+  "IntersectionObserver",
+  "ResizeObserver",
+  "MutationObserver",
+  "PerformanceObserver",
+]);
+const LISTENER_TARGETS = new Set(["window", "document"]);
+
+/** Does this function look like a component (PascalCase name or returns JSX)? */
+const isComponentLike = (fn: FunctionNode): boolean => {
+  const name = getFunctionName(fn);
+  if (name && /^[A-Z]/.test(name)) return true;
+  if (fn.type === "ArrowFunctionExpression" && isJSXElementOrFragment(fn.body)) return true;
+  if (fn.body.type === "BlockStatement") {
+    return fn.body.body.some(
+      (statement) =>
+        statement.type === "ReturnStatement" && isJSXElementOrFragment(statement.argument)
+    );
+  }
+  return false;
+};
+
+/*
+ * Side-effectful setup in a component body runs during setup — including on
+ * the server during SSR, and before the DOM has settled. `onSettled` runs
+ * client-side at the right time. `onCleanup` itself is never flagged: it is
+ * legitimate and lower-overhead than an `onSettled` return-cleanup; a paired
+ * `onCleanup` is a symptom of setup work that belongs in `onSettled`, not the
+ * offense.
+ */
+export default createRule<Options, MessageIds>({
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Enforce running side-effectful setup (timers, global listeners, observers) inside `onSettled` instead of the component body.",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/prefer-onSettled-for-side-effects.md",
+    },
+    schema: [],
+    messages: {
+      sideEffectInBody:
+        "{{name}} in the component body runs during setup, including on the server during SSR. Move it into `onSettled(() => { ...; return cleanup; })` so it runs client-side once the DOM has settled.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const report = (node: T.Node, name: string) => {
+      // Only flag calls made directly in a component body; the same call
+      // inside onSettled, an effect, or an event handler is fine.
+      const enclosingFunction = findParent(node, isFunctionNode);
+      if (!enclosingFunction || !isComponentLike(enclosingFunction)) return;
+      context.report({ node, messageId: "sideEffectInBody", data: { name } });
+    };
+
+    return {
+      CallExpression(node) {
+        const { callee } = node;
+        if (callee.type === "Identifier" && TIMER_CALLS.has(callee.name)) {
+          report(node, `\`${callee.name}\``);
+        } else if (
+          callee.type === "MemberExpression" &&
+          !callee.computed &&
+          callee.property.type === "Identifier" &&
+          callee.property.name === "addEventListener" &&
+          callee.object.type === "Identifier" &&
+          LISTENER_TARGETS.has(callee.object.name)
+        ) {
+          report(node, `\`${callee.object.name}.addEventListener\``);
+        }
+      },
+      NewExpression(node) {
+        if (node.callee.type === "Identifier" && OBSERVER_CONSTRUCTORS.has(node.callee.name)) {
+          report(node, `\`new ${node.callee.name}\``);
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-solid/src/rules/prefer-structured-class.ts
+++ b/packages/eslint-plugin-solid/src/rules/prefer-structured-class.ts
@@ -1,0 +1,117 @@
+import type { TSESLint } from "@typescript-eslint/utils";
+import { TSESTree as T, ESLintUtils } from "@typescript-eslint/utils";
+import { getSourceCode } from "../compat";
+
+const createRule = ESLintUtils.RuleCreator.withoutDocs;
+
+type MessageIds = "manualClassString" | "useStructuredForm";
+type Options = [];
+
+/** Does this expression contain a runtime-varying part (conditional, logical, or call)? */
+const containsDynamicPart = (node: T.Node): boolean => {
+  switch (node.type) {
+    case "ConditionalExpression":
+    case "LogicalExpression":
+    case "CallExpression":
+      return true;
+    case "BinaryExpression":
+      return (
+        node.operator === "+" && (containsDynamicPart(node.left) || containsDynamicPart(node.right))
+      );
+    case "TemplateLiteral":
+      return node.expressions.some(containsDynamicPart);
+    default:
+      return false;
+  }
+};
+
+const isStringLiteral = (node: T.Node): node is T.StringLiteral =>
+  node.type === "Literal" && typeof node.value === "string";
+
+const isEmptyString = (node: T.Node): boolean => isStringLiteral(node) && node.value === "";
+
+/*
+ * In Solid 2.0, `class` accepts arrays and objects natively
+ * (`ClassValue = string | number | boolean | null | undefined |
+ * Record<string, boolean> | ClassValue[]`), and toggles only the affected
+ * classes. Manually-built strings — the React/classnames reflex — still work
+ * but re-run the whole concatenation on every change. This rule nudges toward
+ * either structured form; it imposes no preference between array and object.
+ */
+export default createRule<Options, MessageIds>({
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Enforce using the structured array/object forms of the `class` prop over manually-built class strings.",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/prefer-structured-class.md",
+    },
+    hasSuggestions: true,
+    schema: [],
+    messages: {
+      manualClassString:
+        "Manually building class strings re-runs the whole expression on every change. In Solid 2.0, `class` accepts arrays and objects directly: `class={[base, { active: active() }]}`.",
+      useStructuredForm: "Convert to the structured array form.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const sourceCode = getSourceCode(context);
+
+    /**
+     * Build a suggestion for the simple binary shape
+     * `"base " + (cond ? "cls" : "")` -> `["base", cond && "cls"]`.
+     * Returns null for anything more complex.
+     */
+    const simpleBinarySuggestion = (
+      expression: T.Expression
+    ): ((fixer: TSESLint.RuleFixer) => TSESLint.RuleFix) | null => {
+      if (expression.type !== "BinaryExpression" || expression.operator !== "+") return null;
+      const { left, right } = expression;
+      if (!isStringLiteral(left) || right.type !== "ConditionalExpression") return null;
+      if (!isEmptyString(right.alternate)) return null;
+
+      const base = left.value.trim();
+      if (!base) return null;
+      const test = sourceCode.getText(right.test);
+      const consequent = sourceCode.getText(right.consequent);
+      return (fixer) =>
+        fixer.replaceText(expression, `[${JSON.stringify(base)}, ${test} && ${consequent}]`);
+    };
+
+    return {
+      JSXAttribute(node) {
+        if (node.name.type !== "JSXIdentifier" || node.name.name !== "class") return;
+        if (node.value?.type !== "JSXExpressionContainer") return;
+        const expression = node.value.expression;
+        if (expression.type === "JSXEmptyExpression") return;
+
+        let manual = false;
+        if (expression.type === "TemplateLiteral") {
+          // `btn-${kind}` (plain interpolation) is fine; conditionals inside are not.
+          manual = expression.expressions.some(containsDynamicPart);
+        } else if (expression.type === "BinaryExpression" && expression.operator === "+") {
+          manual = containsDynamicPart(expression);
+        } else if (
+          expression.type === "CallExpression" &&
+          expression.callee.type === "MemberExpression" &&
+          expression.callee.property.type === "Identifier" &&
+          expression.callee.property.name === "join"
+        ) {
+          // [..].join(" ") or [..].filter(Boolean).join(" ")
+          manual = true;
+        }
+        if (!manual) return;
+
+        const suggestionFix = simpleBinarySuggestion(expression);
+        context.report({
+          node: expression,
+          messageId: "manualClassString",
+          suggest: suggestionFix
+            ? [{ messageId: "useStructuredForm", fix: suggestionFix }]
+            : undefined,
+        });
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-solid/src/rules/reactivity.ts
+++ b/packages/eslint-plugin-solid/src/rules/reactivity.ts
@@ -18,6 +18,7 @@ import {
   ignoreTransparentWrappers,
   getFunctionName,
   isJSXElementOrFragment,
+  isSolidV2,
   trace,
 } from "../utils";
 import { findVariable, CompatContext, getSourceCode } from "../compat";
@@ -299,6 +300,9 @@ export default createRule<Options, MessageIds>({
 
     /** Tracks imports from 'solid-js', handling aliases. */
     const { matchImport, handleImportDeclaration } = trackImports();
+
+    /** Solid 2.0 mode (settings.solid.version >= 2). */
+    const v2 = isSolidV2(context);
 
     /**
      * Async/generator functions that are tracked scopes for Solid 2.0 async computations
@@ -605,7 +609,10 @@ export default createRule<Options, MessageIds>({
               isJSXElementOrFragment(elementOrAttribute) ||
               // We can't say for sure about user components, but we know for a fact that a signal
               // should not be passed to a non-event handler DOM element attribute without calling it.
-              (elementOrAttribute?.type === "JSXAttribute" &&
+              // In v2 mode this case is delegated to solid/no-accessor-as-prop so the same
+              // node never gets two reports.
+              (!v2 &&
+                elementOrAttribute?.type === "JSXAttribute" &&
                 elementOrAttribute.parent?.type === "JSXOpeningElement" &&
                 elementOrAttribute.parent.name.type === "JSXIdentifier" &&
                 isDOMElementName(elementOrAttribute.parent.name.name))

--- a/packages/eslint-plugin-solid/src/rules/removed-api.ts
+++ b/packages/eslint-plugin-solid/src/rules/removed-api.ts
@@ -1,0 +1,206 @@
+import type { TSESLint } from "@typescript-eslint/utils";
+import { TSESTree as T, ESLintUtils } from "@typescript-eslint/utils";
+import { findVariable } from "../compat";
+import { jsxGetProp } from "../utils";
+
+const createRule = ESLintUtils.RuleCreator.withoutDocs;
+
+// Mechanical renames: same semantics, new name. Verified against the Solid 2.0
+// RC source (packages/solid/src/index.ts).
+const RENAMED = new Map<string, string>([
+  ["batch", "flush"],
+  ["equalFn", "isEqual"],
+  ["getListener", "getObserver"],
+  ["onMount", "onSettled"],
+  ["mergeProps", "merge"],
+  ["unwrap", "snapshot"],
+]);
+
+// Removed APIs whose replacement requires a structural rewrite; the message is
+// prescriptive but no autofix is offered.
+const REMOVED = new Map<string, string>([
+  [
+    "createResource",
+    "Async derivation is built into Solid 2.0 computations. Use an async `createMemo(async () => ...)` and read it where needed",
+  ],
+  [
+    "createComputed",
+    "Use `createMemo` for derived values or the two-argument `createEffect(compute, effect)` for side effects",
+  ],
+  ["createDeferred", "There is no direct replacement; move the deferral out of the reactive graph"],
+  ["createSelector", "Use `createProjection` to derive per-key reactive state"],
+  [
+    "on",
+    "Explicit dependencies are built in: use the two-argument `createEffect(compute, effect)` form, where `compute` reads the dependencies",
+  ],
+  ["onError", "Use `createErrorBoundary` (or the `<Errored>` component) to handle errors"],
+  ["catchError", "Use `createErrorBoundary` (or the `<Errored>` component) to handle errors"],
+  [
+    "resetErrorBoundaries",
+    "Error boundaries heal automatically in Solid 2.0 when their sources update",
+  ],
+  [
+    "startTransition",
+    "Transitions are built in. Read pending state with `isPending(...)` and previous values with `latest(...)`",
+  ],
+  [
+    "useTransition",
+    "Transitions are built in. Read pending state with `isPending(...)` and previous values with `latest(...)`",
+  ],
+  ["from", "Signals interop with async iterables directly in Solid 2.0"],
+  ["observable", "Signals interop with async iterables directly in Solid 2.0"],
+  ["indexArray", "Use `mapArray`, which handles index-mode mapping in Solid 2.0"],
+  [
+    "splitProps",
+    'Use `omit` from "solid-js" to exclude props, and pass the original props object along',
+  ],
+  ["createMutable", "Use `createStore`; store setters mutate directly in Solid 2.0"],
+  ["modifyMutable", "Use `createStore`; store setters mutate directly in Solid 2.0"],
+  [
+    "produce",
+    "Store setters receive a mutable draft by default in Solid 2.0; mutate directly in the setter",
+  ],
+  // Components
+  ["Index", "Use `<For keyed={false}>`, which passes item accessors like `<Index>` did"],
+  ["ErrorBoundary", "Use `<Errored>` (or `createErrorBoundary`)"],
+  ["Suspense", "Use `<Loading>` to render a fallback while content is pending"],
+  ["SuspenseList", "Use `<Reveal>` with `createRevealOrder` to coordinate reveal order"],
+]);
+
+// Exports that moved from "solid-js/store" into core "solid-js" unchanged.
+const STORE_MOVED = new Set(["createStore", "reconcile", "Store", "StoreNode"]);
+
+const SOLID_SOURCE_REGEX = /^solid-js(?:\/web|\/store)?$/;
+
+type MessageIds = "renamed" | "removed" | "webMoved" | "storeMoved" | "classList";
+type Options = [];
+
+export default createRule<Options, MessageIds>({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow Solid 1.x APIs that were removed or renamed in Solid 2.0, with migration guidance.",
+      url: "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/removed-api.md",
+    },
+    fixable: "code",
+    schema: [],
+    messages: {
+      renamed: "'{{name}}' was renamed to '{{replacement}}' in Solid 2.0.",
+      removed: "'{{name}}' was removed in Solid 2.0. {{guidance}}.",
+      webMoved: 'The "solid-js/web" module is now the "@solidjs/web" package in Solid 2.0.',
+      storeMoved:
+        'The "solid-js/store" module no longer exists in Solid 2.0; \'{{name}}\' is exported from "solid-js".',
+      classList:
+        "The `classList` prop was removed in Solid 2.0; `class` accepts the same object form directly.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    /** Rename the import specifier and, when it isn't aliased, all its references. */
+    const renameFix = (
+      fixer: TSESLint.RuleFixer,
+      specifier: T.ImportSpecifier,
+      replacement: string
+    ): Array<TSESLint.RuleFix> => {
+      const fixes: Array<TSESLint.RuleFix> = [];
+      const aliased = specifier.local.range[0] !== specifier.imported.range[0];
+      fixes.push(fixer.replaceText(specifier.imported, replacement));
+      if (!aliased) {
+        const variable = findVariable(context, specifier.local);
+        if (variable) {
+          for (const reference of variable.references) {
+            if (reference.identifier !== specifier.local) {
+              fixes.push(fixer.replaceText(reference.identifier, replacement));
+            }
+          }
+        }
+      }
+      return fixes;
+    };
+
+    return {
+      ImportDeclaration(node) {
+        const source = node.source.value;
+        if (!SOLID_SOURCE_REGEX.test(source)) return;
+
+        if (source === "solid-js/web") {
+          context.report({
+            node: node.source,
+            messageId: "webMoved",
+            fix: (fixer) =>
+              fixer.replaceText(
+                node.source,
+                node.source.raw.replace("solid-js/web", "@solidjs/web")
+              ),
+          });
+        }
+
+        for (const specifier of node.specifiers) {
+          if (specifier.type !== "ImportSpecifier") continue;
+          const importedName =
+            specifier.imported.type === "Identifier"
+              ? specifier.imported.name
+              : specifier.imported.value;
+
+          const replacement = RENAMED.get(importedName);
+          if (replacement) {
+            context.report({
+              node: specifier,
+              messageId: "renamed",
+              data: { name: importedName, replacement },
+              fix: (fixer) => renameFix(fixer, specifier, replacement),
+            });
+            continue;
+          }
+
+          const guidance = REMOVED.get(importedName);
+          if (guidance) {
+            context.report({
+              node: specifier,
+              messageId: "removed",
+              data: { name: importedName, guidance },
+            });
+            continue;
+          }
+
+          if (source === "solid-js/store" && STORE_MOVED.has(importedName)) {
+            context.report({
+              node: specifier,
+              messageId: "storeMoved",
+              data: { name: importedName },
+              // Only offer the source rewrite when every specifier in this
+              // declaration survives the move; otherwise the fix would create
+              // a broken import of a removed API from "solid-js".
+              fix: node.specifiers.every(
+                (s) =>
+                  s.type === "ImportSpecifier" &&
+                  STORE_MOVED.has(
+                    s.imported.type === "Identifier" ? s.imported.name : s.imported.value
+                  )
+              )
+                ? (fixer) =>
+                    fixer.replaceText(
+                      node.source,
+                      node.source.raw.replace("solid-js/store", "solid-js")
+                    )
+                : undefined,
+            });
+          }
+        }
+      },
+      JSXAttribute(node) {
+        if (node.name.type === "JSXIdentifier" && node.name.name === "classList") {
+          const element = node.parent as T.JSXOpeningElement;
+          const hasClass = !!jsxGetProp(element.attributes, "class");
+          context.report({
+            node: node.name,
+            messageId: "classList",
+            // If a `class` prop already exists the two must be merged by hand.
+            fix: hasClass ? undefined : (fixer) => fixer.replaceText(node.name, "class"),
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-solid/src/utils.ts
+++ b/packages/eslint-plugin-solid/src/utils.ts
@@ -4,6 +4,33 @@ import { CompatContext, findVariable } from "./compat";
 const domElementRegex = /^[a-z]/;
 export const isDOMElementName = (name: string): boolean => domElementRegex.test(name);
 
+interface HasSettings {
+  settings?: TSESLint.SharedConfigurationSettings;
+}
+
+/**
+ * Read the targeted Solid version from `settings: { solid: { version: 2 } }`.
+ * Returns the major version number, or `null` when unset — meaning rules should
+ * use permissive dual-version behavior (accept both 1.x and 2.x patterns).
+ */
+export function getSolidVersion(context: HasSettings): number | null {
+  const solidSettings = context.settings?.solid;
+  if (solidSettings && typeof solidSettings === "object" && "version" in solidSettings) {
+    const version = (solidSettings as { version: unknown }).version;
+    if (typeof version === "number" && Number.isInteger(version) && version > 0) {
+      return version;
+    }
+    if (typeof version === "string") {
+      const major = parseInt(version, 10);
+      if (Number.isInteger(major) && major > 0) return major;
+    }
+  }
+  return null;
+}
+
+/** Whether the targeted Solid version is 2.x or later. */
+export const isSolidV2 = (context: HasSettings): boolean => (getSolidVersion(context) ?? 0) >= 2;
+
 const propsRegex = /[pP]rops/;
 export const isPropsByName = (name: string): boolean => propsRegex.test(name);
 

--- a/packages/eslint-plugin-solid/test/rules/event-handlers.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/event-handlers.test.ts
@@ -22,6 +22,21 @@ export const cases = run("event-handlers", rule, {
     let el = <div {...{ onClick }} />;`,
     { code: `let el = <div onclick={onclick} />`, options: [{ ignoreCase: true }] },
     { code: `let el = <div only={only} />`, options: [{ ignoreCase: true }] },
+    // Solid 2.0: camelCase handlers with functions are correct
+    {
+      code: `let el = <button onClick={() => setCount(count() + 1)} />;`,
+      settings: { solid: { version: 2 } },
+    },
+    // Solid 2.0: lowercase on* with a static string is a legitimate literal
+    // attribute (e.g. a native inline handler)
+    {
+      code: `let el = <div onclick="alert('hi')" />;`,
+      settings: { solid: { version: 2 } },
+    },
+    {
+      code: `let el = <div only="static" />;`,
+      settings: { solid: { version: 2 } },
+    },
   ],
   invalid: [
     {
@@ -159,6 +174,59 @@ export const cases = run("event-handlers", rule, {
       errors: [{ messageId: "spread-handler", data: { name: "onClick" } }],
       output: `const handleClick = () => 42;
       let el = <div  onClick={handleClick} />;`,
+    },
+    // Solid 2.0: lowercase on* with a function value is a listener that never fires
+    {
+      code: `let el = <div onclick={() => setCount(1)} />;`,
+      settings: { solid: { version: 2 } },
+      errors: [
+        { messageId: "lowercase-attribute-v2", data: { name: "onclick", fixedName: "onClick" } },
+      ],
+      output: `let el = <div onClick={() => setCount(1)} />;`,
+    },
+    {
+      code: `let el = <div ondoubleclick={() => {}} />;`,
+      settings: { solid: { version: 2 } },
+      errors: [
+        {
+          messageId: "lowercase-attribute-v2",
+          data: { name: "ondoubleclick", fixedName: "onDblClick" },
+        },
+      ],
+      output: `let el = <div onDblClick={() => {}} />;`,
+    },
+    {
+      // unknown event: suggestion only, since the intent is ambiguous
+      code: `let el = <div onfoobar={() => {}} />;`,
+      settings: { solid: { version: 2 } },
+      errors: [
+        {
+          messageId: "lowercase-attribute-v2",
+          data: { name: "onfoobar", fixedName: "onFoobar" },
+          suggestions: [
+            {
+              messageId: "make-handler",
+              data: { name: "onfoobar", handlerName: "onFoobar" },
+              output: `let el = <div onFoobar={() => {}} />;`,
+            },
+          ],
+        },
+      ],
+    },
+    // Solid 2.0: camelCase handler with a static value can't be a listener
+    {
+      code: `let el = <div onClick="alert('hi')" />;`,
+      settings: { solid: { version: 2 } },
+      errors: [{ messageId: "static-handler-v2" }],
+    },
+    {
+      // onDoubleClick lowercases to a nonexistent DOM event; fix to onDblClick
+      code: `let el = <div onDoubleClick={() => {}} />;`,
+      settings: { solid: { version: 2 } },
+      errors: [
+        { messageId: "nonstandard", data: { name: "onDoubleClick", fixedName: "onDblClick" } },
+      ],
+      output: `let el = <div onDblClick={() => {}} />;`,
     },
   ],
 });

--- a/packages/eslint-plugin-solid/test/rules/imports.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/imports.test.ts
@@ -17,6 +17,21 @@ export const cases = run("imports", rule, {
 import type { Store } from "solid-js/store";`,
       [tsOnly]: true,
     },
+    // Solid 2.0 mode: store/core exports moved into "solid-js" and web moved
+    // to "@solidjs/web"; legacy subpaths are solid/removed-api's territory.
+    {
+      code: `import { createSignal, createStore, reconcile, merge } from "solid-js";`,
+      settings: { solid: { version: 2 } },
+    },
+    {
+      code: `import { render, Portal, Dynamic, isServer } from "@solidjs/web";`,
+      settings: { solid: { version: 2 } },
+    },
+    {
+      // legacy subpaths are ignored here (removed-api reports them)
+      code: `import { createStore } from "solid-js/store";`,
+      settings: { solid: { version: 2 } },
+    },
   ],
   invalid: [
     {
@@ -112,6 +127,31 @@ import { render, createEffect } from "solid-js";`,
       output: `
 import { render } from "solid-js/web";
 import {  createEffect } from "solid-js";`,
+    },
+    // Solid 2.0: web exports live in "@solidjs/web", not core
+    {
+      code: `import { render } from "solid-js";`,
+      settings: { solid: { version: 2 } },
+      errors: [
+        {
+          messageId: "prefer-source",
+          data: { name: "render", source: "@solidjs/web" },
+        },
+      ],
+      output: `import { render } from "@solidjs/web";
+`,
+    },
+    {
+      code: `import { createSignal } from "@solidjs/web";`,
+      settings: { solid: { version: 2 } },
+      errors: [
+        {
+          messageId: "prefer-source",
+          data: { name: "createSignal", source: "solid-js" },
+        },
+      ],
+      output: `import { createSignal } from "solid-js";
+`,
     },
   ],
 });

--- a/packages/eslint-plugin-solid/test/rules/jsx-no-undef.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/jsx-no-undef.test.ts
@@ -174,5 +174,24 @@ import { For } from "solid-js";
 import X from "x"; // attached comment
 let el = <For each={items}>{item => item.name}</For>`,
     },
+    // Solid 2.0: new control-flow components are auto-importable
+    {
+      code: `let el = <Repeat count={5}>{(i) => <div>{i}</div>}</Repeat>;`,
+      settings: { solid: { version: 2 } },
+      errors: [{ messageId: "autoImport", data: { imports: "'Repeat'", source: "solid-js" } }],
+      output: `import { Repeat } from "solid-js";\nlet el = <Repeat count={5}>{(i) => <div>{i}</div>}</Repeat>;`,
+    },
+    {
+      code: `let el = <Loading fallback={spinner}>{content}</Loading>;`,
+      settings: { solid: { version: 2 } },
+      errors: [{ messageId: "autoImport", data: { imports: "'Loading'", source: "solid-js" } }],
+      output: `import { Loading } from "solid-js";\nlet el = <Loading fallback={spinner}>{content}</Loading>;`,
+    },
+    {
+      // Index no longer exists in 2.0, so it isn't auto-imported; plain undefined
+      code: `let el = <Index each={items} />;`,
+      settings: { solid: { version: 2 } },
+      errors: [{ messageId: "undefined", data: { identifier: "Index" } }],
+    },
   ],
 });

--- a/packages/eslint-plugin-solid/test/rules/no-accessor-as-prop.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/no-accessor-as-prop.test.ts
@@ -1,0 +1,96 @@
+import { run } from "../ruleTester";
+import rule from "../../src/rules/no-accessor-as-prop";
+
+export const cases = run("no-accessor-as-prop", rule, {
+  valid: [
+    // called accessors are values
+    `import { createSignal } from "solid-js";
+const [count] = createSignal(0);
+let el = <div title={count()} />;`,
+    `import { createMemo } from "solid-js";
+const label = createMemo(() => "hi");
+let el = <input value={label()} />;`,
+    // event handlers and refs legitimately take functions
+    `import { createSignal } from "solid-js";
+const [count, setCount] = createSignal(0);
+let el = <button onClick={() => setCount(count() + 1)} ref={register} />;`,
+    // components may accept function props; only DOM elements are checked
+    `import { createSignal } from "solid-js";
+const [count] = createSignal(0);
+let el = <Counter value={count} />;`,
+    // custom elements are skipped
+    `import { createSignal } from "solid-js";
+const [count] = createSignal(0);
+let el = <my-element value={count} />;`,
+    // unresolvable identifiers are left alone
+    `let el = <div title={title} />;`,
+    // non-accessor values
+    `let el = <div title={"hello"} tabindex={0} />;`,
+  ],
+  invalid: [
+    {
+      code: `import { createSignal } from "solid-js";
+const [count] = createSignal(0);
+let el = <div title={count} />;`,
+      errors: [
+        {
+          messageId: "accessorAsProp",
+          data: { attribute: "title", name: "count" },
+          suggestions: [
+            {
+              messageId: "accessorAsProp",
+              data: { attribute: "title", name: "count" },
+              output: `import { createSignal } from "solid-js";
+const [count] = createSignal(0);
+let el = <div title={count()} />;`,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `import { createMemo } from "solid-js";
+const label = createMemo(() => "hi");
+let el = <input value={label} />;`,
+      errors: [
+        {
+          messageId: "accessorAsProp",
+          data: { attribute: "value", name: "label" },
+          suggestions: [
+            {
+              messageId: "accessorAsProp",
+              data: { attribute: "value", name: "label" },
+              output: `import { createMemo } from "solid-js";
+const label = createMemo(() => "hi");
+let el = <input value={label()} />;`,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      // plain functions are wrong in value-typed attributes too
+      code: `const getTitle = () => "hello";
+let el = <div title={getTitle} />;`,
+      errors: [
+        {
+          messageId: "functionAsProp",
+          data: { attribute: "title" },
+          suggestions: [
+            {
+              messageId: "functionAsProp",
+              data: { attribute: "title" },
+              output: `const getTitle = () => "hello";
+let el = <div title={getTitle()} />;`,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      // inline arrow function
+      code: `let el = <div title={() => "hello"} />;`,
+      errors: [{ messageId: "functionAsProp", data: { attribute: "title" } }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-solid/test/rules/no-module-scope-reactive-primitive.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/no-module-scope-reactive-primitive.test.ts
@@ -1,0 +1,44 @@
+import { run } from "../ruleTester";
+import rule from "../../src/rules/no-module-scope-reactive-primitive";
+
+export const cases = run("no-module-scope-reactive-primitive", rule, {
+  valid: [
+    // inside a component
+    `import { createSignal } from "solid-js";
+function Counter() {
+  const [count, setCount] = createSignal(0);
+  return <div>{count()}</div>;
+}`,
+    // inside any function (custom primitives, providers)
+    `import { createStore } from "solid-js";
+export function createTodos() {
+  const [todos, setTodos] = createStore([]);
+  return [todos, setTodos];
+}`,
+    // createRoot is the deliberate escape hatch: the primitive is inside its callback
+    `import { createRoot, createSignal } from "solid-js";
+const counter = createRoot(() => createSignal(0));`,
+  ],
+  invalid: [
+    {
+      code: `import { createSignal } from "solid-js";
+const [count, setCount] = createSignal(0);`,
+      errors: [{ messageId: "moduleScopePrimitive", data: { name: "createSignal" } }],
+    },
+    {
+      code: `import { createStore } from "solid-js";
+export const [state, setState] = createStore({ user: null });`,
+      errors: [{ messageId: "moduleScopePrimitive", data: { name: "createStore" } }],
+    },
+    {
+      code: `import { createMemo } from "solid-js";
+const doubled = createMemo(() => count() * 2);`,
+      errors: [{ messageId: "moduleScopePrimitive", data: { name: "createMemo" } }],
+    },
+    {
+      code: `import { createEffect } from "solid-js";
+createEffect(count, (c) => console.log(c));`,
+      errors: [{ messageId: "moduleScopePrimitive", data: { name: "createEffect" } }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-solid/test/rules/no-react-deps.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/no-react-deps.test.ts
@@ -22,6 +22,12 @@ export const cases = run("no-react-deps", rule, {
     `const sum = createMemo((prev) => input() + prev, 0);`,
     `const args = [() => { console.log(signal()); }, [signal()]];
     createEffect(...args);`,
+    // In Solid 2.0 the rule self-gates off: the second argument is the
+    // required effect function, so the 1.x premise no longer exists.
+    {
+      code: `createEffect(() => console.log(signal()), [signal]);`,
+      settings: { solid: { version: 2 } },
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin-solid/test/rules/no-restated-default-options.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/no-restated-default-options.test.ts
@@ -1,0 +1,52 @@
+import { run } from "../ruleTester";
+import rule from "../../src/rules/no-restated-default-options";
+
+export const cases = run("no-restated-default-options", rule, {
+  valid: [
+    // non-default values are meaningful
+    `let el = <For each={items()} keyed={false}>{(item) => <div />}</For>;`,
+    `let el = <Show when={user()} keyed>{(u) => <div />}</Show>;`,
+    `let el = <For each={items()} keyed={rowKey}>{(item) => <div />}</For>;`,
+    // no keyed prop at all
+    `let el = <For each={items()}>{(item) => <div />}</For>;`,
+    `let el = <Show when={user()}><div /></Show>;`,
+    // unknown components are left alone
+    `let el = <Grid keyed={true} />;`,
+  ],
+  invalid: [
+    {
+      code: `let el = <For each={items()} keyed={true}>{(item) => <div />}</For>;`,
+      errors: [
+        { messageId: "restatedDefault", data: { prop: "keyed", value: "true", component: "For" } },
+      ],
+      output: `let el = <For each={items()} >{(item) => <div />}</For>;`,
+    },
+    {
+      code: `let el = <For each={items()} keyed>{(item) => <div />}</For>;`,
+      errors: [
+        { messageId: "restatedDefault", data: { prop: "keyed", value: "true", component: "For" } },
+      ],
+      output: `let el = <For each={items()} >{(item) => <div />}</For>;`,
+    },
+    {
+      code: `let el = <Show when={user()} keyed={false}><div /></Show>;`,
+      errors: [
+        {
+          messageId: "restatedDefault",
+          data: { prop: "keyed", value: "false", component: "Show" },
+        },
+      ],
+      output: `let el = <Show when={user()} ><div /></Show>;`,
+    },
+    {
+      code: `let el = <Match when={cond()} keyed={false}><div /></Match>;`,
+      errors: [
+        {
+          messageId: "restatedDefault",
+          data: { prop: "keyed", value: "false", component: "Match" },
+        },
+      ],
+      output: `let el = <Match when={cond()} ><div /></Match>;`,
+    },
+  ],
+});

--- a/packages/eslint-plugin-solid/test/rules/no-single-arg-create-effect.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/no-single-arg-create-effect.test.ts
@@ -1,0 +1,25 @@
+import { run } from "../ruleTester";
+import rule from "../../src/rules/no-single-arg-create-effect";
+
+export const cases = run("no-single-arg-create-effect", rule, {
+  valid: [
+    `import { createEffect } from "solid-js";
+createEffect(() => count(), (value) => console.log(value));`,
+    `import { createEffect } from "solid-js";
+createEffect(count, (value) => console.log(value), { name: "logger" });`,
+    `import { createRenderEffect } from "solid-js";
+createRenderEffect(() => count(), (value) => update(value));`,
+  ],
+  invalid: [
+    {
+      code: `import { createEffect } from "solid-js";
+createEffect(() => console.log(count()));`,
+      errors: [{ messageId: "singleArgEffect" }],
+    },
+    {
+      code: `import { createRenderEffect } from "solid-js";
+createRenderEffect(() => update(count()));`,
+      errors: [{ messageId: "singleArgRenderEffect" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-solid/test/rules/no-unknown-namespaces.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/no-unknown-namespaces.test.ts
@@ -17,6 +17,29 @@ export const cases = run("no-unknown-namespaces", rule, {
       options: [{ allowedNamespaces: ["foo"] }],
       code: `let el = <bar foo="http://www.w3.org/2000/svg" version="1.1" foo:bar="http://www.w3.org/1999/xlink" />`,
     },
+    // Solid 2.0: any colon-name is a legal literal attribute
+    {
+      code: `let el = <div foo:boo="literal" />;`,
+      settings: { solid: { version: 2 } },
+    },
+    {
+      code: `let el = <div prop:scrollTop="0px" />;`,
+      settings: { solid: { version: 2 } },
+    },
+    {
+      code: `let el = <div class:mt-10 style:width="100%" />;`,
+      settings: { solid: { version: 2 } },
+    },
+    {
+      code: `let el = <svg xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="#a" /></svg>;`,
+      settings: { solid: { version: 2 } },
+    },
+    {
+      // explicitly allowed 1.x prefix is not flagged even in v2
+      options: [{ allowedNamespaces: ["use"] }],
+      code: `let el = <div use:X={null} />;`,
+      settings: { solid: { version: 2 } },
+    },
   ],
   invalid: [
     {
@@ -72,6 +95,32 @@ export const cases = run("no-unknown-namespaces", rule, {
           ],
         },
       ],
+    },
+    // Solid 2.0: formerly-public prefixes silently render literal attributes
+    {
+      code: `let el = <div on:click={handler} />;`,
+      settings: { solid: { version: 2 } },
+      errors: [{ messageId: "v2Namespace" }],
+    },
+    {
+      code: `let el = <div use:X={null} />;`,
+      settings: { solid: { version: 2 } },
+      errors: [{ messageId: "v2Namespace" }],
+    },
+    {
+      code: `let el = <div attr:title="title" />;`,
+      settings: { solid: { version: 2 } },
+      errors: [{ messageId: "v2Namespace" }],
+    },
+    {
+      code: `let el = <div bool:disabled={cond()} />;`,
+      settings: { solid: { version: 2 } },
+      errors: [{ messageId: "v2Namespace" }],
+    },
+    {
+      code: `let el = <div oncapture:click={handler} />;`,
+      settings: { solid: { version: 2 } },
+      errors: [{ messageId: "v2Namespace" }],
     },
   ],
 });

--- a/packages/eslint-plugin-solid/test/rules/prefer-onSettled-for-side-effects.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/prefer-onSettled-for-side-effects.test.ts
@@ -1,0 +1,69 @@
+import { run } from "../ruleTester";
+import rule from "../../src/rules/prefer-onSettled-for-side-effects";
+
+export const cases = run("prefer-onSettled-for-side-effects", rule, {
+  valid: [
+    // setup inside onSettled is the goal state
+    `import { onSettled } from "solid-js";
+function Timer() {
+  onSettled(() => {
+    const timer = setInterval(tick, 1000);
+    return () => clearInterval(timer);
+  });
+  return <div />;
+}`,
+    // inside an event handler is fine
+    `function App() {
+  const start = () => setInterval(tick, 1000);
+  return <button onClick={start} />;
+}`,
+    // non-component functions are not flagged
+    `function schedulePoll() {
+  setInterval(poll, 5000);
+}`,
+    // onCleanup alone is never the offense
+    `import { onCleanup } from "solid-js";
+function App() {
+  onCleanup(() => subscription.dispose());
+  return <div />;
+}`,
+    // element listeners (non-global) are not flagged
+    `function App() {
+  let el;
+  el.addEventListener("click", handler);
+  return <div />;
+}`,
+  ],
+  invalid: [
+    {
+      code: `function Timer() {
+  const timer = setInterval(tick, 1000);
+  return <div />;
+}`,
+      errors: [{ messageId: "sideEffectInBody" }],
+    },
+    {
+      code: `import { onCleanup } from "solid-js";
+function App() {
+  window.addEventListener("resize", onResize);
+  onCleanup(() => window.removeEventListener("resize", onResize));
+  return <div />;
+}`,
+      errors: [{ messageId: "sideEffectInBody" }],
+    },
+    {
+      code: `const App = () => {
+  const observer = new ResizeObserver(callback);
+  return <div />;
+};`,
+      errors: [{ messageId: "sideEffectInBody" }],
+    },
+    {
+      code: `const Widget = () => {
+  document.addEventListener("keydown", onKey);
+  return <div />;
+};`,
+      errors: [{ messageId: "sideEffectInBody" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-solid/test/rules/prefer-structured-class.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/prefer-structured-class.test.ts
@@ -1,0 +1,47 @@
+import { run } from "../ruleTester";
+import rule from "../../src/rules/prefer-structured-class";
+
+export const cases = run("prefer-structured-class", rule, {
+  valid: [
+    // structured forms — the goal state
+    `let el = <div class={["btn", { active: active() }]} />;`,
+    `let el = <div class={{ btn: true, active: active() }} />;`,
+    // static strings are fine
+    `let el = <div class="btn primary" />;`,
+    `let el = <div class={"btn"} />;`,
+    // plain interpolation without conditionals is fine
+    "let el = <div class={`btn-${kind}`} />;",
+    // static concatenation is fine
+    `let el = <div class={"btn" + "-primary"} />;`,
+    // other attributes are not this rule's business
+    `let el = <div title={"a " + (b() ? "c" : "")} />;`,
+  ],
+  invalid: [
+    {
+      code: `let el = <div class={"btn " + (active() ? "active" : "")} />;`,
+      errors: [
+        {
+          messageId: "manualClassString",
+          suggestions: [
+            {
+              messageId: "useStructuredForm",
+              output: `let el = <div class={["btn", active() && "active"]} />;`,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: 'let el = <div class={`btn ${active() ? "active" : ""}`} />;',
+      errors: [{ messageId: "manualClassString" }],
+    },
+    {
+      code: `let el = <div class={[base, active() && "on"].filter(Boolean).join(" ")} />;`,
+      errors: [{ messageId: "manualClassString" }],
+    },
+    {
+      code: `let el = <div class={"btn " + variant() + " large"} />;`,
+      errors: [{ messageId: "manualClassString" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-solid/test/rules/removed-api.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/removed-api.test.ts
@@ -1,0 +1,89 @@
+import { run } from "../ruleTester";
+import rule from "../../src/rules/removed-api";
+
+export const cases = run("removed-api", rule, {
+  valid: [
+    `import { createSignal, createMemo, createEffect } from "solid-js";`,
+    `import { merge, omit, flush, snapshot, isEqual, onSettled } from "solid-js";`,
+    `import { For, Repeat, Show, Switch, Match, Errored, Loading, Reveal } from "solid-js";`,
+    `import { createStore, reconcile } from "solid-js";`,
+    `import { render, Portal, Dynamic } from "@solidjs/web";`,
+    `import { something } from "somewhere/else";`,
+    `let el = <div class={{ active: true }} />;`,
+    `let el = <div class="btn" />;`,
+  ],
+  invalid: [
+    // mechanical renames with reference rewriting
+    {
+      code: `import { onMount } from "solid-js";
+onMount(() => console.log("hi"));`,
+      errors: [{ messageId: "renamed", data: { name: "onMount", replacement: "onSettled" } }],
+      output: `import { onSettled } from "solid-js";
+onSettled(() => console.log("hi"));`,
+    },
+    {
+      code: `import { batch } from "solid-js";
+batch(() => update());`,
+      errors: [{ messageId: "renamed", data: { name: "batch", replacement: "flush" } }],
+      output: `import { flush } from "solid-js";
+flush(() => update());`,
+    },
+    {
+      code: `import { mergeProps } from "solid-js";
+const props2 = mergeProps({ a: 1 }, props);`,
+      errors: [{ messageId: "renamed", data: { name: "mergeProps", replacement: "merge" } }],
+      output: `import { merge } from "solid-js";
+const props2 = merge({ a: 1 }, props);`,
+    },
+    // aliased import: only the imported name changes
+    {
+      code: `import { onMount as om } from "solid-js";
+om(() => {});`,
+      errors: [{ messageId: "renamed", data: { name: "onMount", replacement: "onSettled" } }],
+      output: `import { onSettled as om } from "solid-js";
+om(() => {});`,
+    },
+    // removed APIs: prescriptive message, no fix
+    {
+      code: `import { createResource } from "solid-js";`,
+      errors: [{ messageId: "removed" }],
+    },
+    {
+      code: `import { on, useTransition } from "solid-js";`,
+      errors: [{ messageId: "removed" }, { messageId: "removed" }],
+    },
+    {
+      code: `import { Index, Suspense, ErrorBoundary } from "solid-js";`,
+      errors: [{ messageId: "removed" }, { messageId: "removed" }, { messageId: "removed" }],
+    },
+    // module moves
+    {
+      code: `import { render } from "solid-js/web";`,
+      errors: [{ messageId: "webMoved" }],
+      output: `import { render } from "@solidjs/web";`,
+    },
+    {
+      code: `import { createStore } from "solid-js/store";`,
+      errors: [{ messageId: "storeMoved", data: { name: "createStore" } }],
+      output: `import { createStore } from "solid-js";`,
+    },
+    {
+      code: `import { createStore, produce } from "solid-js/store";`,
+      errors: [
+        { messageId: "storeMoved", data: { name: "createStore" } },
+        { messageId: "removed" },
+      ],
+    },
+    // classList -> class
+    {
+      code: `let el = <div classList={{ active: isActive() }} />;`,
+      errors: [{ messageId: "classList" }],
+      output: `let el = <div class={{ active: isActive() }} />;`,
+    },
+    {
+      // can't autofix when a `class` prop already exists
+      code: `let el = <div class="btn" classList={{ active: isActive() }} />;`,
+      errors: [{ messageId: "classList" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-solid/tsup.config.ts
+++ b/packages/eslint-plugin-solid/tsup.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/configs/recommended.ts", "src/configs/typescript.ts"],
+  entry: [
+    "src/index.ts",
+    "src/configs/recommended.ts",
+    "src/configs/typescript.ts",
+    "src/configs/v2.ts",
+    "src/configs/v2-strict.ts",
+  ],
   format: ["cjs", "esm"],
   dts: true,
   // experimentalDts: true,

--- a/packages/eslint-solid-standalone/package.json
+++ b/packages/eslint-solid-standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-solid-standalone",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "A bundle with eslint and eslint-plugin-solid that can be used in the browser.",
   "repository": "https://github.com/solidjs-community/eslint-plugin-solid",
   "license": "MIT",

--- a/test/.oxlintrc.json
+++ b/test/.oxlintrc.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
   "jsPlugins": ["eslint-plugin-solid"],
+  "settings": { "solid": { "version": 2 } },
   "rules": {
     "solid/jsx-no-duplicate-props": "error",
     "solid/jsx-no-undef": "error",
@@ -17,6 +18,13 @@
     "solid/style-prop": "warn",
     "solid/no-react-deps": "warn",
     "solid/no-react-specific-props": "warn",
-    "solid/self-closing-comp": "warn"
+    "solid/self-closing-comp": "warn",
+    "solid/removed-api": "error",
+    "solid/no-single-arg-create-effect": "error",
+    "solid/no-accessor-as-prop": "error",
+    "solid/prefer-structured-class": "warn",
+    "solid/no-module-scope-reactive-primitive": "warn",
+    "solid/prefer-onSettled-for-side-effects": "warn",
+    "solid/no-restated-default-options": "warn"
   }
 }

--- a/test/eslint.config.v2.js
+++ b/test/eslint.config.v2.js
@@ -1,0 +1,17 @@
+// @ts-check
+
+import tseslint from "typescript-eslint";
+import globals from "globals";
+import v2Config from "eslint-plugin-solid/configs/v2";
+
+export default tseslint.config({
+  files: ["templates-v2/**/*.{js,jsx,ts,tsx}"],
+  ...v2Config,
+  languageOptions: {
+    globals: globals.browser,
+    parser: tseslint.parser,
+    parserOptions: {
+      project: null,
+    },
+  },
+});

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -2,6 +2,8 @@ import { test, expect, expectTypeOf } from "vitest";
 
 import recommendedConfig from "eslint-plugin-solid/configs/recommended";
 import typescriptConfig from "eslint-plugin-solid/configs/typescript";
+import v2Config from "eslint-plugin-solid/configs/v2";
+import v2StrictConfig from "eslint-plugin-solid/configs/v2-strict";
 import plugin from "eslint-plugin-solid";
 import type * as standalone from "eslint-solid-standalone";
 
@@ -10,11 +12,29 @@ test("flat config has meta", () => {
   expect(recommendedConfig.plugins.solid.meta.version).toEqual(expect.any(String));
   expect(typescriptConfig.plugins.solid.meta.name).toBe("eslint-plugin-solid");
   expect(typescriptConfig.plugins.solid.meta.version).toEqual(expect.any(String));
+  expect(v2Config.plugins.solid.meta.name).toBe("eslint-plugin-solid");
+  expect(v2StrictConfig.plugins.solid.meta.name).toBe("eslint-plugin-solid");
 });
 
 test("flat configs are exposed on plugin.configs", () => {
   expect(plugin.configs.recommended).toBe(recommendedConfig);
   expect(plugin.configs.typescript).toBe(typescriptConfig);
+  expect(plugin.configs.v2).toBe(v2Config);
+  expect(plugin.configs["v2-strict"]).toBe(v2StrictConfig);
+});
+
+test("v2 configs set the Solid version and enable the 2.0 rules", () => {
+  expect(v2Config.settings.solid.version).toBe(2);
+  expect(v2StrictConfig.settings.solid.version).toBe(2);
+  expect(v2Config.rules["solid/removed-api"]).toBe(2);
+  expect(v2Config.rules["solid/no-single-arg-create-effect"]).toBe(2);
+  expect(v2Config.rules["solid/no-accessor-as-prop"]).toBe(2);
+  expect(v2Config.rules["solid/prefer-structured-class"]).toBe(1);
+  expect(v2Config.rules["solid/prefer-classlist"]).toBe(0);
+  expect(v2StrictConfig.rules["solid/no-module-scope-reactive-primitive"]).toBe(2);
+  expect(v2StrictConfig.rules["solid/prefer-onSettled-for-side-effects"]).toBe(1);
+  expect(v2StrictConfig.rules["solid/no-restated-default-options"]).toBe(2);
+  expect(v2StrictConfig.rules["solid/prefer-structured-class"]).toBe(2);
 });
 
 test('flat configs are also exposed on plugin.configs["flat/*"] for compatibility', () => {

--- a/test/lint-templates.mjs
+++ b/test/lint-templates.mjs
@@ -1,0 +1,72 @@
+// Local template vetting harness: runs the solid v2 config over the real
+// Solid 2.0 templates in a sibling checkout. Expected result: zero errors and
+// zero warnings. Not run in CI (CI uses the fixture copies in templates-v2/);
+// run manually with `node lint-templates.mjs [path-to-templates-checkout]`.
+import path from "node:path";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+import { ESLint } from "eslint";
+import tseslint from "typescript-eslint";
+import globals from "globals";
+import v2Config from "eslint-plugin-solid/configs/v2";
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const templatesRoot = path.resolve(dirname, process.argv[2] ?? "../../templates");
+
+if (!fs.existsSync(templatesRoot)) {
+  console.error(`Templates checkout not found at ${templatesRoot}`);
+  process.exit(2);
+}
+
+// Only solid-v2/* targets Solid 2.0. The solid-start-v2/* directory is
+// SolidStart 2.0, which still runs Solid 1.x — linting it with the v2 config
+// correctly reports its 1.x patterns, which is noise here. (When SolidStart
+// moves to Solid 2.0, add "solid-start-v2" back.)
+const groups = ["solid-v2"].filter((g) => fs.existsSync(path.join(templatesRoot, g)));
+
+const eslint = new ESLint({
+  cwd: templatesRoot,
+  overrideConfigFile: true,
+  overrideConfig: [
+    // generated files (e.g. TanStack Router route trees) are not template code
+    { ignores: ["**/*.gen.ts", "**/*.d.ts"] },
+    {
+      files: ["**/*.{js,jsx,ts,tsx}"],
+      ...v2Config,
+      languageOptions: {
+        ...v2Config.languageOptions,
+        globals: globals.browser,
+        parser: tseslint.parser,
+        parserOptions: { ecmaFeatures: { jsx: true } },
+      },
+    },
+  ],
+});
+
+let errorCount = 0;
+let warningCount = 0;
+for (const group of groups) {
+  const templates = fs
+    .readdirSync(path.join(templatesRoot, group), { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name);
+  for (const template of templates) {
+    const srcDir = path.join(templatesRoot, group, template, "src");
+    if (!fs.existsSync(srcDir)) continue;
+    const results = await eslint.lintFiles(path.join(srcDir, "**/*.{js,jsx,ts,tsx}"));
+    for (const result of results) {
+      errorCount += result.errorCount;
+      warningCount += result.warningCount;
+      for (const message of result.messages) {
+        const rel = path.relative(templatesRoot, result.filePath);
+        const severity = message.severity === 2 ? "error" : "warn";
+        console.log(
+          `${rel}:${message.line}:${message.column} [${severity}] ${message.ruleId ?? "parse"}: ${message.message}`
+        );
+      }
+    }
+  }
+}
+
+console.log(`\n${errorCount} errors, ${warningCount} warnings`);
+process.exit(errorCount + warningCount > 0 ? 1 : 0);

--- a/test/templates-v2/bare/App.tsx
+++ b/test/templates-v2/bare/App.tsx
@@ -1,0 +1,25 @@
+import { createSignal } from "solid-js";
+import logo from "./logo.svg";
+import "./App.css";
+
+// The app root: a plain content component — the document shell lives in
+// src/Document.tsx. This file is the whole demo; replace its contents to
+// start your app.
+export default function App() {
+  const [count, setCount] = createSignal(0);
+
+  return (
+    <header class="header">
+      <img src={logo} class="logo" alt="Solid logo" />
+      <p>
+        Edit <code>src/App.tsx</code> and save to reload.
+      </p>
+      <button class="increment" onClick={() => setCount(count() + 1)}>
+        Clicks: {count()}
+      </button>
+      <a class="link" href="https://v2.solidjs.com/" target="_blank" rel="noopener noreferrer">
+        Learn Solid
+      </a>
+    </header>
+  );
+}

--- a/test/templates-v2/bare/Document.tsx
+++ b/test/templates-v2/bare/Document.tsx
@@ -1,0 +1,24 @@
+import type { ParentProps } from "solid-js";
+import { HydrationScript } from "@solidjs/web";
+
+// The document shell — the new index.html: picked up by the src/Document.*
+// convention, it wraps the app in the plugin's generated entries and must
+// render the full <html>. Head tags go here. It is compiled only into the
+// prerendered static shell and ships zero client-side JS: in client mode
+// <HydrationScript /> is stripped from the shell, and it activates when the
+// app flips to SSR (`ssr: true` in vite.config.ts) — no document changes
+// needed. Delete this file to fall back to the plugin's built-in shell.
+export default function Document(props: ParentProps) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="icon" href="/favicon.ico" />
+        <title>Solid App</title>
+        <HydrationScript />
+      </head>
+      <body>{props.children}</body>
+    </html>
+  );
+}

--- a/test/templates-v2/basic/App.tsx
+++ b/test/templates-v2/basic/App.tsx
@@ -1,0 +1,23 @@
+import { Title } from "@solidjs/meta";
+import { Loading } from "solid-js";
+import { paths, Router } from "./router";
+import "./App.css";
+
+// The app root: the router and the site-wide layout live here. Pages are
+// the modules under src/routes.
+export default function App() {
+  return (
+    <Router>
+      {(props) => (
+        <>
+          <Title>Solid App</Title>
+          <nav>
+            <a href={paths()}>Home</a>
+            <a href={paths.users(1)}>Users</a>
+          </nav>
+          <Loading fallback={<main>Loading…</main>}>{props.children}</Loading>
+        </>
+      )}
+    </Router>
+  );
+}

--- a/test/templates-v2/basic/Document.tsx
+++ b/test/templates-v2/basic/Document.tsx
@@ -1,0 +1,24 @@
+import type { ParentProps } from "solid-js";
+import { HydrationScript } from "@solidjs/web";
+
+// The document shell — the new index.html: picked up by the src/Document.*
+// convention, it wraps the app in the plugin's generated entries and must
+// render the full <html>. Head tags go here. It is compiled only into the
+// prerendered static shell and ships zero client-side JS: in client mode
+// <HydrationScript /> is stripped from the shell, and it activates when the
+// app flips to SSR (`ssr: true` in vite.config.ts) — no document changes
+// needed. Delete this file to fall back to the plugin's built-in shell.
+export default function Document(props: ParentProps) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="icon" href="/favicon.ico" />
+        <title>Solid App</title>
+        <HydrationScript />
+      </head>
+      <body>{props.children}</body>
+    </html>
+  );
+}

--- a/test/templates-v2/basic/components/Counter.test.tsx
+++ b/test/templates-v2/basic/components/Counter.test.tsx
@@ -1,0 +1,17 @@
+import { render, fireEvent } from "@solidjs/testing-library";
+import { flush } from "solid-js";
+import { describe, expect, test } from "vitest";
+
+import Counter from "./Counter";
+
+describe("<Counter />", () => {
+  test("it increments on click", () => {
+    const { getByRole } = render(() => <Counter />);
+    const button = getByRole("button");
+    expect(button).toHaveTextContent("Clicks: 0");
+    fireEvent.click(button);
+    // Solid batches DOM updates; flush() applies them synchronously.
+    flush();
+    expect(button).toHaveTextContent("Clicks: 1");
+  });
+});

--- a/test/templates-v2/basic/components/Counter.tsx
+++ b/test/templates-v2/basic/components/Counter.tsx
@@ -1,0 +1,10 @@
+import { createSignal } from "solid-js";
+
+export default function Counter() {
+  const [count, setCount] = createSignal(0);
+  return (
+    <button class="increment" onClick={() => setCount(count() + 1)} type="button">
+      Clicks: {count()}
+    </button>
+  );
+}

--- a/test/templates-v2/basic/router.ts
+++ b/test/templates-v2/basic/router.ts
@@ -1,0 +1,7 @@
+import { pageRoutes } from "virtual:file-routes";
+import { createRouter } from "@solidjs/router";
+import { fileRoutes } from "@solidjs/router/fs";
+
+export const Router = createRouter({ routes: fileRoutes(pageRoutes) });
+
+export const { paths } = Router;

--- a/test/templates-v2/basic/routes/[...404].tsx
+++ b/test/templates-v2/basic/routes/[...404].tsx
@@ -1,0 +1,26 @@
+import { Title } from "@solidjs/meta";
+import type { RouteDefinition } from "@solidjs/router";
+import { httpStatus } from "@solidjs/web";
+
+// The catch-all route. httpStatus() is a no-op in the browser and takes
+// effect when SSR is enabled; it runs in preload so the status code is set
+// before the response head flushes.
+export const route = {
+  preload: () => httpStatus(404),
+} satisfies RouteDefinition;
+
+export default function NotFound() {
+  return (
+    <main>
+      <Title>Not Found - Solid App</Title>
+      <h1>Page Not Found</h1>
+      <p>
+        Visit{" "}
+        <a href="https://docs.solidjs.com" target="_blank" rel="noreferrer">
+          docs.solidjs.com
+        </a>{" "}
+        to learn how to build Solid apps.
+      </p>
+    </main>
+  );
+}

--- a/test/templates-v2/basic/routes/index.tsx
+++ b/test/templates-v2/basic/routes/index.tsx
@@ -1,0 +1,20 @@
+import { Title } from "@solidjs/meta";
+import Counter from "../components/Counter";
+import logo from "../logo.svg";
+
+export default function Home() {
+  return (
+    <main>
+      <Title>Home - Solid App</Title>
+      <img src={logo} class="logo" alt="Solid logo" />
+      <h1>Hello Solid!</h1>
+      <Counter />
+      <p>
+        Edit <code>src/routes/index.tsx</code> and save to reload.
+      </p>
+      <a href="https://v2.solidjs.com/" target="_blank" rel="noopener noreferrer">
+        Learn Solid
+      </a>
+    </main>
+  );
+}

--- a/test/templates-v2/basic/routes/users.tsx
+++ b/test/templates-v2/basic/routes/users.tsx
@@ -1,0 +1,12 @@
+import type { ParentProps } from "solid-js";
+
+// A layout route: pairing users.tsx with the users/ directory nests every
+// page inside it under this component.
+export default function UsersLayout(props: ParentProps) {
+  return (
+    <main>
+      <h1>Users</h1>
+      {props.children}
+    </main>
+  );
+}

--- a/test/templates-v2/basic/routes/users/[id].tsx
+++ b/test/templates-v2/basic/routes/users/[id].tsx
@@ -1,0 +1,37 @@
+import { Title } from "@solidjs/meta";
+import { query, type RouteDefinition, type RouteProps } from "@solidjs/router";
+import { getRequestEvent } from "@solidjs/web";
+import { createMemo } from "solid-js";
+import { paths } from "../../router";
+
+// Async data loading: a query (cached per key) read through a memo — the
+// surrounding <Loading> boundary (in App.tsx) shows its fallback until the
+// promise settles. Swap the static JSON for any API endpoint.
+const getUser = query(async (id: string) => {
+  // Same-origin URLs need an explicit origin when this runs during SSR
+  // (getRequestEvent() is undefined in the browser, where location wins).
+  const origin = getRequestEvent()?.request.url ?? location.origin;
+  const response = await fetch(new URL("/users.json", origin));
+  const users: Record<string, { name: string; title: string }> = await response.json();
+  return users[id] ?? { name: "Unknown", title: "No such user" };
+}, "user");
+
+// Starts the fetch as soon as navigation begins, before the page renders.
+export const route = {
+  preload: ({ params }) => void getUser(params.id!),
+} satisfies RouteDefinition;
+
+export default function User(props: RouteProps<"/users/:id">) {
+  const user = createMemo(() => getUser(props.params.id));
+
+  return (
+    <section>
+      <Title>{`User ${props.params.id} - Solid App`}</Title>
+      <h2>{user().name}</h2>
+      <p>{user().title}</p>
+      <p>
+        <a href={paths.users(Number(props.params.id) + 1)}>Next user</a>
+      </p>
+    </section>
+  );
+}

--- a/test/templates.test.ts
+++ b/test/templates.test.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "vitest";
+
+import path from "path";
+import { ESLint } from "eslint";
+
+// The templates-v2/ directory contains sources copied from the official Solid
+// 2.0 templates (github.com/solidjs/templates, solid-v2/*). The v2 config is
+// what those templates ship, so it must produce zero findings on them. The
+// full sibling-checkout sweep lives in lint-templates.mjs (local only).
+const cwd = __dirname;
+
+test.concurrent("solid 2.0 template fixtures lint clean under configs/v2", async () => {
+  const eslint = new ESLint({
+    cwd,
+    overrideConfigFile: "./eslint.config.v2.js",
+  } as any);
+  const results = await eslint.lintFiles("templates-v2/**/*.{js,jsx,ts,tsx}");
+
+  expect(results.length).toBeGreaterThan(0);
+  for (const result of results) {
+    const rel = path.relative(cwd, result.filePath);
+    expect.soft(result.messages, rel).toEqual([]);
+    expect.soft(result.errorCount, rel).toBe(0);
+    expect.soft(result.warningCount, rel).toBe(0);
+  }
+});

--- a/test/vitest.config.js
+++ b/test/vitest.config.js
@@ -1,5 +1,10 @@
+import { defaultExclude } from "vitest/config";
+
 export default {
   test: {
     globals: true,
+    // templates-v2/ contains lint fixtures copied from the Solid templates
+    // repo, including a *.test.tsx file that is not a test of this package
+    exclude: [...defaultExclude, "templates-v2/**"],
   },
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,5 @@
     "allowImportingTsExtensions": true
   },
   "include": ["packages/eslint-plugin-solid", "packages/eslint-solid-standalone", "test", "scripts"],
-  "exclude": ["**/dist", "**/dist.*"]
+  "exclude": ["**/dist", "**/dist.*", "test/templates-v2"]
 }


### PR DESCRIPTION
## Summary

- Adds `settings.solid.version` plumbing (`getSolidVersion`/`isSolidV2` in utils) so rules adapt behavior without forks; new `v2` and `v2-strict` flat configs preset it.
- Seven new rules: `removed-api` (renames autofixed, removals get prescriptive guidance), `no-single-arg-create-effect`, `no-accessor-as-prop`, `prefer-structured-class`, and strict-tier `no-module-scope-reactive-primitive`, `prefer-onSettled-for-side-effects`, `no-restated-default-options`.
- Version-2 behavior in existing rules: `event-handlers` (camelCase is the only handler form; lowercase is a literal attribute), `no-unknown-namespaces` (namespaces no longer reserved; flags 1.x migration bugs), `imports` (2.0 export locations), `jsx-no-undef` (2.0 control-flow auto-imports incl. `Repeat`/`Errored`/`Loading`/`Reveal`), `reactivity` (delegates DOM-attribute badSignal to `no-accessor-as-prop`), `no-react-deps` (self-gates off in v2).
- Template vetting: `v2` config produces zero findings on the official Solid 2.0 templates; representative sources checked in as CI fixtures with a lint test, plus a local sweep script for the sibling templates checkout.
- Rule docs (generated CASES), README config docs, CHANGELOG; verified under Oxlint `jsPlugins` with v2 settings.

## Test plan

- [x] `pnpm run ci` green (lint, tsc, build, 1775 + 9 tests)
- [x] Template fixture lint test asserts zero errors/warnings under the `v2` config
- [x] Oxlint smoke test fires the new rules with v2 semantics

Made with [Cursor](https://cursor.com)