### PR TITLE
reactivity: detect stale captures in returned functions, stop warning on returned accessors

### DIFF
--- a/packages/eslint-plugin-solid/docs/reactivity.md
+++ b/packages/eslint-plugin-solid/docs/reactivity.md
@@ -239,6 +239,40 @@ iteration's `await`. Event handlers, `on*` lifecycle callbacks, and `action` fun
 tracked scopes, so reads after `await` there remain allowed—they intentionally poll current
 values.
 
+### Stale captures in returned functions
+
+A signal called at the setup level of a hook or component, with its value captured in a variable
+that a *returned* function reads, is almost always a bug: the returned function looks live but
+reads a value frozen at setup.
+
+```jsx
+const [items, setItems] = createSignal([]);
+
+function useCartTotal() {
+  const list = items(); // ⚠️ 'list' captures the value of 'items' at setup
+  return () => list.reduce((sum, item) => sum + item.price, 0);
+}
+```
+
+The fix is to call the signal inside the returned function, so every call reads the current
+value:
+
+```jsx
+function useCartTotal() {
+  return () => items().reduce((sum, item) => sum + item.price, 0); // ✅
+}
+```
+
+If a one-time snapshot is genuinely intended, opt in with the same naming convention used for
+props: prefix the variable with `initial`, `default`, or `static` (e.g. `const initialItems =
+items()`), or wrap the read in `untrack`.
+
+Relatedly, functions *directly returned* from another function (`return () => items().length` or
+`const useDouble = () => () => count() * 2`) are not required to match a tracked scope in the
+file that defines them. Returning an accessor is the custom-primitive contract—the caller decides
+whether it lands in JSX, an effect, or an event handler—so the rule no longer warns on the
+idiomatic hook shape.
+
 <!-- doc-gen CASES -->
 ## Tests
 
@@ -549,6 +583,30 @@ const total = createMemo(async () => {
   }
   return sum;
 });
+
+const [items, setItems] = createSignal([]);
+function useCartTotal() {
+  const list = items();
+  return () => list.reduce((sum, item) => sum + item.price, 0);
+}
+
+const [items, setItems] = createSignal([]);
+function useCount() {
+  const total = items().length;
+  return () => total;
+}
+
+const [theme, setTheme] = createSignal("dark");
+function Component() {
+  const current = theme();
+  return <button onClick={() => console.log(current)}>theme</button>;
+}
+
+const [count, setCount] = createSignal(0);
+function useStale() {
+  const value = count();
+  return () => value + 1;
+}
 
 ```
 
@@ -1108,6 +1166,34 @@ function Component(props) {
       {(item, index) => <div data-index={index()}>{item.name}</div>}
     </For>
   );
+}
+
+const [items, setItems] = createSignal([]);
+function useCartTotal() {
+  return () => items().reduce((sum, item) => sum + item.price, 0);
+}
+
+const [count, setCount] = createSignal(0);
+const useDouble = () => () => count() * 2;
+
+const [count, setCount] = createSignal(0);
+function useCounter() {
+  return function current() {
+    return count();
+  };
+}
+
+const [items, setItems] = createSignal([]);
+function useTotal() {
+  const initialItems = items();
+  return () => initialItems.length;
+}
+
+const [items, setItems] = createSignal([]);
+function useTotal() {
+  const list = items();
+  console.log(list);
+  return () => items().length;
 }
 
 ```

--- a/packages/eslint-plugin-solid/src/rules/reactivity.ts
+++ b/packages/eslint-plugin-solid/src/rules/reactivity.ts
@@ -230,7 +230,8 @@ type MessageIds =
   | "shouldDestructure"
   | "shouldAssign"
   | "noAsyncTrackedScope"
-  | "readAfterAwait";
+  | "readAfterAwait"
+  | "staleCapture";
 type Options = [{ customReactiveFunctions: string[] }];
 
 export default createRule<Options, MessageIds>({
@@ -276,6 +277,8 @@ export default createRule<Options, MessageIds>({
         "This tracked scope should not be async. Solid's reactivity only tracks synchronously.",
       readAfterAwait:
         "The reactive variable '{{name}}' is read after this computation suspends (at an 'await' or 'yield'), so changes to it won't be tracked. Read it before the first 'await' and store the result in a variable.",
+      staleCapture:
+        "'{{captured}}' captures the value of the reactive variable '{{name}}' at setup, but a returned function reads the capture later — it will never update. Call '{{name}}' inside the returned function instead, or prefix '{{captured}}' with 'initial'/'default'/'static' if a one-time snapshot is intended.",
     },
   },
   defaultOptions: [
@@ -399,6 +402,99 @@ export default createRule<Options, MessageIds>({
       }
     };
 
+    /**
+     * Returns true when `fn` is directly returned by the enclosing function:
+     * either the argument of a `return` statement or the whole body of an
+     * arrow function. Deliberately strict — a function that merely appears
+     * somewhere inside a returned expression (e.g. a runWithOwner callback
+     * in a returned call) is not "returned" for our purposes.
+     */
+    const isDirectlyReturned = (fn: FunctionNode): boolean =>
+      fn.parent?.type === "ReturnStatement" ||
+      (fn.parent?.type === "ArrowFunctionExpression" && fn.parent.body === fn);
+
+    /**
+     * Detects the stale-capture footgun: a signal called at a function's
+     * setup level, its result captured in a variable, and that variable read
+     * by a function the enclosing function *returns*. The returned function
+     * pretends to be live but reads a value frozen at setup. Reports and
+     * returns true when found.
+     */
+    const checkStaleCapture = (identifier: T.Identifier): boolean => {
+      const call = identifier.parent;
+      if (call?.type !== "CallExpression" || call.callee !== identifier) return false;
+      // Find the VariableDeclarator whose init contains this call, walking up
+      // through intermediate expressions (`const t = items().length`) but
+      // never through a statement or another function.
+      let child: T.Node = call;
+      while (
+        child.parent &&
+        child.parent.type !== "VariableDeclarator" &&
+        !isFunctionNode(child.parent) &&
+        !child.parent.type.endsWith("Statement")
+      ) {
+        child = child.parent;
+      }
+      const declarator = child.parent;
+      if (declarator?.type !== "VariableDeclarator" || declarator.init !== child) return false;
+
+      const currentScopeNode = currentScope().node;
+      const capturedVars = sourceCode.scopeManager?.getDeclaredVariables(declarator) ?? [];
+      for (const captured of capturedVars) {
+        // The initial/default/static naming convention opts into a one-time
+        // snapshot, same as for props reads.
+        if (/^(?:initial|default|static[A-Z])/.test(captured.name)) continue;
+        for (const reference of captured.references) {
+          if (reference.init) continue;
+          if (isCapturedInReturnedFunction(reference.identifier, currentScopeNode)) {
+            context.report({
+              node: call,
+              messageId: "staleCapture",
+              data: { name: identifier.name, captured: captured.name },
+            });
+            return true;
+          }
+        }
+      }
+      return false;
+    };
+
+    /**
+     * Returns true when `node` sits inside a nested function that escapes the
+     * `boundary` function through a `return` statement (including functions
+     * embedded in returned JSX or objects).
+     */
+    const isCapturedInReturnedFunction = (
+      node: T.Node,
+      boundary: ProgramOrFunctionNode
+    ): boolean => {
+      // Find the outermost function strictly inside `boundary` containing `node`.
+      let outermost: FunctionNode | null = null;
+      let cursor: T.Node | null = node;
+      while (cursor && cursor !== boundary) {
+        if (isFunctionNode(cursor)) outermost = cursor;
+        cursor = cursor.parent ?? null;
+      }
+      if (!cursor || !outermost) return false; // not under boundary, or not captured by a closure
+      // Walk from that function to `boundary`; only non-function nodes remain
+      // in between, so a ReturnStatement found here belongs to `boundary`.
+      let child: T.Node = outermost;
+      let parent: T.Node | null = child.parent ?? null;
+      while (parent && child !== boundary) {
+        if (parent.type === "ReturnStatement") return true;
+        if (isFunctionNode(parent)) {
+          return (
+            parent === boundary &&
+            parent.type === "ArrowFunctionExpression" &&
+            parent.body === child
+          );
+        }
+        child = parent;
+        parent = parent.parent ?? null;
+      }
+      return false;
+    };
+
     /** Inspects a specific reference of a reactive variable for correct handling. */
     const handleTrackedScopes = (
       identifier: T.Identifier,
@@ -447,6 +543,13 @@ export default createRule<Options, MessageIds>({
             throw new Error("this shouldn't happen!");
           }
 
+          // Signal called at this function's setup level with its value
+          // captured by a variable that a *returned* function reads: the
+          // returned function will read a stale value forever. Report here —
+          // treating the enclosing function as a derived signal (below) is
+          // still correct, but no call-site discipline can fix the capture.
+          checkStaleCapture(identifier);
+
           // If the current function doesn't have an associated variable, that's
           // fine, it's being used inline (i.e. anonymous arrow function). For
           // this to be okay, the arrow function has to be the same node as one
@@ -454,7 +557,14 @@ export default createRule<Options, MessageIds>({
           const pushUnnamedDerivedSignal = () =>
             (parentScope().unnamedDerivedSignals ??= new Set()).add(currentScopeNode);
 
-          if (currentScopeNode.type === "FunctionDeclaration") {
+          if (isDirectlyReturned(currentScopeNode)) {
+            // A function directly returned by its enclosing function is an
+            // accessor handed to the caller — the custom-primitive contract.
+            // The caller decides whether it lands in a tracked scope; there is
+            // nowhere in this file for it to match a tracked scope, so
+            // requiring one only punishes the idiomatic hook shape
+            // (`return () => signal()`). Do nothing.
+          } else if (currentScopeNode.type === "FunctionDeclaration") {
             // get variable representing function, function node only defines one variable
             const functionVariable: Variable | undefined =
               sourceCode.scopeManager?.getDeclaredVariables(currentScopeNode)?.[0];

--- a/packages/eslint-plugin-solid/test/rules/reactivity.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/reactivity.test.ts
@@ -481,6 +481,31 @@ export const cases = run("reactivity", rule, {
         </For>
       );
     }`,
+    // Returned accessors are the custom-primitive contract: the caller
+    // decides whether they land in a tracked scope. (#213)
+    `const [items, setItems] = createSignal([]);
+    function useCartTotal() {
+      return () => items().reduce((sum, item) => sum + item.price, 0);
+    }`,
+    `const [count, setCount] = createSignal(0);
+    const useDouble = () => () => count() * 2;`,
+    `const [count, setCount] = createSignal(0);
+    function useCounter() {
+      return function current() { return count(); };
+    }`,
+    // Snapshot capture opted into by naming convention (#213)
+    `const [items, setItems] = createSignal([]);
+    function useTotal() {
+      const initialItems = items();
+      return () => initialItems.length;
+    }`,
+    // Captured value only used at setup, not by a returned function
+    `const [items, setItems] = createSignal([]);
+    function useTotal() {
+      const list = items();
+      console.log(list);
+      return () => items().length;
+    }`,
   ],
   invalid: [
     // Untracked signals
@@ -1049,6 +1074,47 @@ export const cases = run("reactivity", rule, {
         return sum;
       });`,
       errors: [{ messageId: "readAfterAwait", line: 7 }],
+    },
+    // Stale captures: signal read at setup, value captured by a variable a
+    // returned function reads — the capture never updates (#213)
+    {
+      code: `
+      const [items, setItems] = createSignal([]);
+      function useCartTotal() {
+        const list = items();
+        return () => list.reduce((sum, item) => sum + item.price, 0);
+      }`,
+      errors: [{ messageId: "staleCapture", line: 4 }],
+    },
+    // Derived-through-expression capture is just as stale
+    {
+      code: `
+      const [items, setItems] = createSignal([]);
+      function useCount() {
+        const total = items().length;
+        return () => total;
+      }`,
+      errors: [{ messageId: "staleCapture", line: 4 }],
+    },
+    // Functions embedded in returned JSX escape the same way
+    {
+      code: `
+      const [theme, setTheme] = createSignal("dark");
+      function Component() {
+        const current = theme();
+        return <button onClick={() => console.log(current)}>theme</button>;
+      }`,
+      errors: [{ messageId: "staleCapture", line: 4 }],
+    },
+    // Implicit arrow return escapes too
+    {
+      code: `
+      const [count, setCount] = createSignal(0);
+      function useStale() {
+        const value = count();
+        return () => value + 1;
+      }`,
+      errors: [{ messageId: "staleCapture", line: 4 }],
     },
   ],
 });


### PR DESCRIPTION
Fixes both halves of #213.

## False negative → new `staleCapture` error

A signal called at a function's setup level, with its value captured in a variable that a **returned** function reads, now reports:

```jsx
const [items, setItems] = createSignal([]);
function useCartTotal() {
  const list = items(); // ⚠️ staleCapture
  return () => list.reduce((sum, item) => sum + item.price, 0);
}
```

- Detection walks through intermediate expressions (`const t = items().length`) but never through statements or other functions.
- Functions embedded in returned JSX count (`return <button onClick={() => use(captured)} />`).
- The `initial`/`default`/`static` naming convention opts into intentional snapshots, mirroring the existing props convention; `untrack()` also suppresses it (the read matches a tracked scope and never reaches the check).
- Only fires when the signal is declared **above** the current function scope — the same-scope case already reports `untrackedReactive` on the setup read, so nothing double-reports.

## False positive → returned accessors exempt from `badUnnamedDerivedSignal`

Functions **directly returned** from another function no longer need to match a tracked scope in the defining file:

```jsx
function useCartTotal() {
  return () => items().reduce((sum, item) => sum + item.price, 0); // ✅ no warning
}
const useDouble = () => () => count() * 2; // ✅ no warning
```

Returning an accessor is the custom-primitive contract — the caller decides whether it lands in JSX, an effect, or a handler, and there is nowhere in the defining file for it to match a tracked scope. The exemption is deliberately strict (direct `return` argument or whole arrow body only), so existing warnings like a `runWithOwner` callback inside a returned call expression are preserved — verified by the existing suite.

## Tests / docs

- 9 new cases (5 valid, 4 invalid); full suite 611/611 passing, build clean.
- New "Stale captures in returned functions" troubleshooting section in `docs/reactivity.md`; generated cases refreshed.

Context: found during an agent evaluation on the solid-v2 templates, where the rule steered a correct minimal fix toward `createMemo` purely to silence the warning, while the actual bug linted clean.

Made with [Cursor](https://cursor.com)