### PR TITLE
reactivity: support object numeric destructuring of signal tuples (#198)

### DIFF
--- a/packages/eslint-plugin-solid/docs/reactivity.md
+++ b/packages/eslint-plugin-solid/docs/reactivity.md
@@ -392,6 +392,10 @@ const Component = () => {
 };
 
 const Component = () => {
+  const { 2: signal, 3: setSignal } = createSignal();
+};
+
+const Component = () => {
   createMemo(() => 5);
 };
 
@@ -841,6 +845,18 @@ element.addEventListener(
   { once: true }
 );
 
+const { 0: signal, 1: setSignal } = createSignal(1);
+const element = document.getElementById("id");
+element.onclick = () => {
+  console.log(signal());
+};
+
+const { "0": signal, "1": setSignal } = createSignal(1);
+const element = document.getElementById("id");
+element.onclick = () => {
+  console.log(signal());
+};
+
 const [signal, setSignal] = createSignal(1);
 const element = document.getElementById("id");
 element.onclick = () => {
@@ -893,11 +909,24 @@ function Component(props) {
 }
 
 function Component(props) {
+  const { 0: count, 1: setCount } = useSignal(props.initialCount);
+  return <div>{count()}</div>;
+}
+
+function Component(props) {
   const [count, setCount] = useSignal(props.defaultCount);
   return <div>{count()}</div>;
 }
 
 const [state, setState] = createStore({
+  firstName: "Will",
+  lastName: "Smith",
+  get fullName() {
+    return state.firstName + " " + state.lastName;
+  },
+});
+
+const { 0: state, 1: setState } = createStore({
   firstName: "Will",
   lastName: "Smith",
   get fullName() {

--- a/packages/eslint-plugin-solid/src/rules/reactivity.ts
+++ b/packages/eslint-plugin-solid/src/rules/reactivity.ts
@@ -7,8 +7,7 @@ import {
   TSESTree as T,
   TSESLint,
   ESLintUtils,
-  ASTUtils,
-  AST_NODE_TYPES,
+  ASTUtils
 } from "@typescript-eslint/utils";
 import { traverse } from "estraverse";
 import {

--- a/packages/eslint-plugin-solid/test/rules/reactivity.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/reactivity.test.ts
@@ -180,6 +180,16 @@ export const cases = run("reactivity", rule, {
     element.addEventListener("click", () => {
       console.log(signal());
     }, { once: true });`,
+    `const {0: signal, 1: setSignal} = createSignal(1);
+    const element = document.getElementById("id");
+    element.onclick = () => {
+      console.log(signal());
+    };`,
+    `const {'0': signal, '1': setSignal} = createSignal(1);
+    const element = document.getElementById("id");
+    element.onclick = () => {
+      console.log(signal());
+    };`,
     `const [signal, setSignal] = createSignal(1);
     const element = document.getElementById("id");
     element.onclick = () => {
@@ -223,11 +233,22 @@ export const cases = run("reactivity", rule, {
       return <div>{count()}</div>;
     }`,
     `function Component(props) {
+      const {0: count, 1: setCount} = useSignal(props.initialCount);
+      return <div>{count()}</div>;
+    }`,
+    `function Component(props) {
       const [count, setCount] = useSignal(props.defaultCount);
       return <div>{count()}</div>;
     }`,
     // Store getters
     `const [state, setState] = createStore({
+      firstName: 'Will',
+      lastName: 'Smith',
+      get fullName() {
+        return state.firstName + " " + state.lastName;
+      }
+    });`,
+    `const {0: state, 1: setState} = createStore({
       firstName: 'Will',
       lastName: 'Smith',
       get fullName() {
@@ -565,6 +586,19 @@ export const cases = run("reactivity", rule, {
           messageId: "shouldDestructure",
           data: { nth: "first " },
           type: T.ArrayPattern,
+        },
+      ],
+    },
+    {
+      code: `
+      const Component = () => {
+        const {2: signal, 3: setSignal} = createSignal();
+      }`,
+      errors: [
+        {
+          messageId: "shouldDestructure",
+          data: { nth: "first " },
+          type: T.ObjectPattern,
         },
       ],
     },

--- a/packages/eslint-plugin-solid/test/rules/reactivity.test.ts
+++ b/packages/eslint-plugin-solid/test/rules/reactivity.test.ts
@@ -736,7 +736,6 @@ export const cases = run("reactivity", rule, {
         {
           messageId: "shouldDestructure",
           data: { nth: "first " },
-          type: T.ObjectPattern,
         },
       ],
     },


### PR DESCRIPTION
## Summary

Lands #198 by @Forelyl (commits preserved): `getNthDestructuredVar` now recognizes object-numeric destructuring of signal tuples (`const { 0: signal, 1: setSignal } = createSignal(...)`, string keys included), which is spec-equivalent to array destructuring.

Includes a small test fixup on top: dropped a `type:` assertion that referenced an unimported namespace (we removed `type` assertions from error objects in 0.15 for ESLint 10 RuleTester compatibility).

## Test plan

- [x] Full workspace CI passes locally (lint, tsc, build, 1856 + 9 tests)

Made with [Cursor](https://cursor.com)